### PR TITLE
updated one line in osx build need to cd into bin dir before running app

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To build using cmake (using the cmake scripts by Kyle Findlay; The following ins
 
 ---------------------------------------------------
 
-To build on OSX (Sierra with latest Homebrew)
+To build on OSX (Sierra (10.12) with latest Homebrew and Xcode)
 
 ```
 $ git clone https://github.com/linleyh/liberation-circuit.git
@@ -76,11 +76,13 @@ $ cd liberation-circuit
 $ brew install allegro
 $ ./do
 
-$ bin/libcirc
+$ cd bin
+
+$ libcirc
 
 ```
 
-Text is pretty small on a Retina screen.
+Text is pretty small on a Retina screen. But it looks and plays perfectly on a 11" or 13" MacBook Air (which are all non-retina).
 
 
 ---------------------------------------------------


### PR DESCRIPTION
Just minor changes to README. You cannot run the game from the root dir on OSX. You must cd into bin and then execute the game. Made this correction to README and added in version of Sierra and Xcode requirement. And extra sentence for how it plays on Mac Book Airs.