### PR TITLE
Fix give_build_command

### DIFF
--- a/src/g_method_std.c
+++ b/src/g_method_std.c
@@ -1027,7 +1027,7 @@ s16b call_std_method(struct core_struct* core, int call_value, int variable_para
 // repeat dealt with below
 
 			return add_to_build_queue(core->player_index,
-																						       core->index,
+																						       transmit_target_core->index,
 																						       stack_parameters [1], // template
 																						       stack_parameters [2], // x
 																						       stack_parameters [3], // y


### PR DESCRIPTION
Calling give_build_command() did not actually give the build command to the transmit target, but to the process calling give_build_command() instead. This fixes that.