### PR TITLE
Redo fixes

### DIFF
--- a/src/default.h.gch.do
+++ b/src/default.h.gch.do
@@ -1,0 +1,2 @@
+redo-ifchange $2.o
+ln $2.o $3

--- a/src/default.o.do
+++ b/src/default.o.do
@@ -2,7 +2,7 @@ deps=$2.deps
 deps_ne=$2.deps_ne
 cflags="-O3 -fwrapv -MD -MF $deps"
 
-if (command -v strace >/dev/null); then
+if command -v strace >/dev/null; then
  # Record non-existence header dependencies.
  # If headers GCC does not find are produced
  # in the future, the target is built again.
@@ -14,9 +14,7 @@ if (command -v strace >/dev/null); then
   >$deps_ne
  rm -f "$deps_ne.in"
 
- while read -r DEP_NE; do
-  redo-ifcreate ${DEP_NE}
- done <$deps_ne
+ xargs redo-ifcreate <$deps_ne
 else
  # Record non-existence strace dependency.
  # When strace is installed in the future,
@@ -25,8 +23,8 @@ else
  (
   IFS=:
   for folder in $PATH; do
-   redo-ifcreate $folder/strace
-  done
+   echo "$folder/strace"
+  done | xargs redo-ifcreate
  )
  gcc $cflags -o $3 -c ${1%.o}.c
 fi

--- a/src/default.o.do
+++ b/src/default.o.do
@@ -2,12 +2,26 @@ deps=$2.deps
 deps_ne=$2.deps_ne
 cflags="-O3 -fwrapv -MD -MF $deps"
 
+if [ "$1" != "precompile.o" ]; then
+ redo-ifchange precompile.h.gch
+ cflags="$cflags -include precompile.h"
+fi
+
+if [ -e "${1%.o}.c" ]; then
+ src="${1%.o}.c"
+elif [ -e "${1%.o}.h" ]; then
+ src="${1%.o}.h"
+else
+ echo "$1: no source file found" >&2
+ exit 99
+fi
+
 if command -v strace >/dev/null; then
  # Record non-existence header dependencies.
  # If headers GCC does not find are produced
  # in the future, the target is built again.
  strace -e stat,stat64,fstat,fstat64,lstat,lstat64 -o "$deps_ne.in" -f \
-  gcc $cflags -o $3 -c ${1%.o}.c
+  gcc $cflags -o $3 -c $src
  grep '1 ENOENT' <$deps_ne.in\
   |grep '\.h'\
   |cut -d'"' -f2\
@@ -26,7 +40,7 @@ else
    echo "$folder/strace"
   done | xargs redo-ifcreate
  )
- gcc $cflags -o $3 -c ${1%.o}.c
+ gcc $cflags -o $3 -c $src
 fi
 
 read DEPS <$deps

--- a/src/default.o.do
+++ b/src/default.o.do
@@ -1,4 +1,3 @@
-#!/bin/sh
 deps=$2.deps
 deps_ne=$2.deps_ne
 cflags="-O3 -fwrapv -MD -MF $deps"
@@ -7,12 +6,13 @@ if (command -v strace >/dev/null); then
  # Record non-existence header dependencies.
  # If headers GCC does not find are produced
  # in the future, the target is built again.
- strace -e stat,stat64,fstat,fstat64,lstat,lstat64 -f 2>&1 >/dev/null \
-  gcc $cflags -o $3 -c ${1%.o}.c\
-  |grep '1 ENOENT'\
+ strace -e stat,stat64,fstat,fstat64,lstat,lstat64 -o "$deps_ne.in" -f \
+  gcc $cflags -o $3 -c ${1%.o}.c
+ grep '1 ENOENT' <$deps_ne.in\
   |grep '\.h'\
   |cut -d'"' -f2\
   >$deps_ne
+ rm -f "$deps_ne.in"
 
  while read -r DEP_NE; do
   redo-ifcreate ${DEP_NE}

--- a/src/g_game.do
+++ b/src/g_game.do
@@ -1,5 +1,4 @@
-#!/bin/sh
 for file in *.c; do
-  redo-ifchange ${file%.*}.o
-done
+  echo "${file%.*}.o"
+done | xargs redo-ifchange
 gcc -O3 -fwrapv -o $3 *.o -lallegro -lm -lallegro_audio -lallegro_acodec -lallegro_font -lallegro_image -lallegro_primitives -lallegro_dialog -lallegro_main

--- a/src/g_game.do
+++ b/src/g_game.do
@@ -1,4 +1,9 @@
-for file in *.c; do
+objs=$(
+ for file in *.c; do
   echo "${file%.*}.o"
-done | xargs redo-ifchange
-gcc -O3 -fwrapv -o $3 *.o -lallegro -lm -lallegro_audio -lallegro_acodec -lallegro_font -lallegro_image -lallegro_primitives -lallegro_dialog -lallegro_main
+ done
+)
+echo "$objs" | xargs redo-ifchange
+gcc -O3 -fwrapv -o $3 $objs \
+    -lallegro -lm -lallegro_audio -lallegro_acodec -lallegro_font \
+    -lallegro_image -lallegro_primitives -lallegro_dialog -lallegro_main

--- a/src/precompile.h
+++ b/src/precompile.h
@@ -1,0 +1,8 @@
+#include "allegro5/allegro_acodec.h"
+#include "allegro5/allegro_audio.h"
+#include <allegro5/allegro.h>
+#include <allegro5/allegro_font.h>
+#include <allegro5/allegro_image.h>
+#include <allegro5/allegro_native_dialog.h>
+#include <allegro5/allegro_opengl.h>
+#include <allegro5/allegro_primitives.h>


### PR DESCRIPTION
This fixes some bugs and inefficiencies in the redo-based build scripts.  In particular, using the redo from https://github.com/apenwarr/redo, we now get a substantial benefit from using 'redo -j10' on my machine.

The initial build is still slower with redo than with make, because:

- default.o.do uses -O3 while the Makefile is not

- default.o.do is much more careful (too careful? :)) about file dependencies, while the Makefile just has *.o depend on *.h.

But at least it's much faster than before.