### PR TITLE
Fix potential out-of-bounds array access in c_prepr.c

### DIFF
--- a/src/c_prepr.c
+++ b/src/c_prepr.c
@@ -380,7 +380,7 @@ int load_source_file(const char* file_path, struct source_struct* target_source)
 
   if (src_pos >= SOURCE_TEXT_LINE_LENGTH - 1)
   {
-   target_source->text [src_line] [src_pos] = '\0'; // if line is too long, terminate it and start new line
+   target_source->text [src_line] [SOURCE_TEXT_LINE_LENGTH-1] = '\0'; // if line is too long, terminate it and start new line
    if (!line_finished) // line is too long and was not terminated by newline
    {
     start_log_line(MLOG_COL_ERROR);


### PR DESCRIPTION
If `src_pos` is equal to **or greater** than `SOURCE_TEXT_LINE_LENGTH-1`, then writing to `array[src_pos]` can possibly result in a write outside array bounds. This changeset makes the code fragment always write to `array[SOURCE_TEXT_LINE_LENGTH-1]`, i.e. the last element within array bounds.