### PR TITLE
Fix inconsistent on-error behaviour in choose_template_file()

### DIFF
--- a/src/t_files.c
+++ b/src/t_files.c
@@ -645,7 +645,7 @@ static int choose_template_file(int filechooser_mode)
  if (file_type != FILE_TYPE_TEMPLATE)
  {
   write_line_to_log("Error: Must be a multi-binary template file with the .tf extension.", MLOG_COL_ERROR);
-  return 0;
+  	goto choose_fail;
  }
 
  strcpy(tfile.template_file_path, file_path_ptr);


### PR DESCRIPTION
In `choose_template_file()`, most error checks ended with `goto check_error;`. However, one check ended with a simple `return 0;`, which resulted in the file dialog not being destroyed properly.