### PR TITLE
Fix "multiple definition" errors

### DIFF
--- a/src/e_complete.c
+++ b/src/e_complete.c
@@ -40,7 +40,7 @@ struct completionstruct completion;
 
 extern struct editorstruct editor; // defined in e_editor.c
 extern struct coloursstruct colours;
-struct fontstruct font [FONTS];
+extern struct fontstruct font [FONTS];
 
 
 //#define COMPLETION_TABLE_SIZE 1200

--- a/src/h_interface.c
+++ b/src/h_interface.c
@@ -1113,7 +1113,7 @@ static void draw_a_story_box(int region_index, float draw_x, float draw_y, times
 }
 
 
-float vertex_list [6] [2];
+static float vertex_list [6] [2];
 
 static void add_orthogonal_hexagon_story(int layer, float x, float y, float size, ALLEGRO_COLOR col1)
 {

--- a/src/i_display.c
+++ b/src/i_display.c
@@ -185,7 +185,7 @@ ALLEGRO_BITMAP* vision_mask;
 
 //ALLEGRO_BITMAP* packet_bmp;
 
-struct fontstruct font [FONTS];
+extern struct fontstruct font [FONTS];
 
 extern struct game_struct game; // in g_game.c
 extern struct dshape_struct dshape [NSHAPES]; // uses same indices as NSHAPES

--- a/src/i_display.c
+++ b/src/i_display.c
@@ -72,7 +72,7 @@ void draw_proc_fail_cloud(struct cloud_struct* cl, float x, float y);
 static void print_object_information(float text_x, float text_y, int col, const char* ostring, int value, int print_value);
 
 #define VERTEX_LIST_SIZE 32
-float vertex_list [VERTEX_LIST_SIZE] [2];
+static float vertex_list [VERTEX_LIST_SIZE] [2];
 
 // call this after setting up the vertex_list array with an appropriate number of vertices
 //static void add_outline_poly_layer(int layer, int vertices, ALLEGRO_COLOR fill_col, ALLEGRO_COLOR edge_col);

--- a/src/p_draw.c
+++ b/src/p_draw.c
@@ -54,7 +54,7 @@ extern ALLEGRO_EVENT_QUEUE* fps_queue;
 extern struct game_struct game; // in g_game.c
 extern struct view_struct view;
 
-char mstring [MENU_STRING_LENGTH];
+extern char mstring [MENU_STRING_LENGTH];
 
 void display_standard_panel(int pan);
 static void print_sysmenu_help(float base_x, float base_y);

--- a/src/p_panels.c
+++ b/src/p_panels.c
@@ -51,7 +51,7 @@ extern ALLEGRO_EVENT_QUEUE* fps_queue;
 extern struct game_struct game; // in g_game.c
 extern struct view_struct view;
 
-char mstring [MENU_STRING_LENGTH];
+extern char mstring [MENU_STRING_LENGTH];
 
 
 

--- a/src/s_menu.c
+++ b/src/s_menu.c
@@ -79,7 +79,7 @@ static void reset_map_for_menu(void);
 static void print_key_codes(void);
 
 
-char mstring [MENU_STRING_LENGTH];
+extern char mstring [MENU_STRING_LENGTH];
 
 #define ELEMENT_NAME_SIZE 30
 

--- a/src/x_music.c
+++ b/src/x_music.c
@@ -41,7 +41,7 @@ extern ALLEGRO_TIMER* sound_timer;
 
 extern struct sound_configstruct sound_config; // in x_sound.c
 
-float tone [TONES];
+extern float tone [TONES];
 
 extern struct synthstruct synth;
 


### PR DESCRIPTION
This changeset fixes compilation errors occurring due to redefined variables.

Solves issue #52.