### PR TITLE
Fixed indentation of `bin/proc` files

### DIFF
--- a/bin/proc/cm_attack.c
+++ b/bin/proc/cm_attack.c
@@ -1,5 +1,3 @@
-
-
 #process "attacker"
 
 // This process has objects with the following auto classes:
@@ -18,59 +16,53 @@ class auto_allocate;
 class auto_stability;
 
 core_quad_A, 0, 
-  {object_pulse:auto_att_fwd, 0},
-  {object_move:auto_move, 2048},
-  {object_none, 0},
-  {object_move:auto_move, -2048},
+	{object_pulse:auto_att_fwd, 0},
+	{object_move:auto_move, 2048},
+	{object_none, 0},
+	{object_move:auto_move, -2048},
 #code
 
-
-
-
 // Process AI modes (these reflect the capabilities of the process)
-enum
-{
-  MODE_IDLE, // process isn't doing anything ongoing
-  MODE_MOVE, // process is moving to target_x, target_y
-  MODE_MOVE_ATTACK, // process is moving, but will attack anything it finds along the way
-  MODE_ATTACK, // process is attacking a target it was commanded to attack
-  MODE_ATTACK_FOUND, // process is attacking a target it found itself
-  MODE_GUARD, // process is circling a friendly process
-  MODES
+enum {
+	MODE_IDLE, // process isn't doing anything ongoing
+	MODE_MOVE, // process is moving to target_x, target_y
+	MODE_MOVE_ATTACK, // process is moving, but will attack anything it finds along the way
+	MODE_ATTACK, // process is attacking a target it was commanded to attack
+	MODE_ATTACK_FOUND, // process is attacking a target it found itself
+	MODE_GUARD, // process is circling a friendly process
+	MODES
 };
 
 // Commands that the user may give the process
 // (these are fixed and should not be changed, although not all processes accept all commands)
-enum
-{
-  COM_NONE, // no command
-  COM_LOCATION, // user has right-clicked somewhere on the display or map
-  COM_TARGET, // user has right-clicked on an enemy process
-  COM_FRIEND, // user has right-clicked on a friendly process
-  COM_DATA_WELL // user has right-clicked on a data well
+enum {
+	COM_NONE, // no command
+	COM_LOCATION, // user has right-clicked somewhere on the display or map
+	COM_TARGET, // user has right-clicked on an enemy process
+	COM_FRIEND, // user has right-clicked on a friendly process
+	COM_DATA_WELL // user has right-clicked on a data well
 };
 
 // Targetting information
 // Targetting memory allows processes to track targets (enemy or friend)
 // The following enums are used as indices in the process' targetting memory
-enum
-{
-  TARGET_PARENT, // a newly built process starts with its builder in address 0
-  TARGET_MAIN, // main target
-  TARGET_FRONT, // target of directional forward attack
-  TARGET_GUARD, // target of guard command
+enum {
+	TARGET_PARENT, // a newly built process starts with its builder in address 0
+	TARGET_MAIN, // main target
+	TARGET_FRONT, // target of directional forward attack
+	TARGET_GUARD, // target of guard command
 };
 
 
 // Variable declaration and initialisation
-//  (note that declaration and initialisation cannot be combined)
-//  (also, variables retain their values between execution cycles)
+// (note that declaration and initialisation cannot be combined)
+// (also, variables retain their values between execution cycles)
 int core_x, core_y; // location of core
 core_x = get_core_x(); // location is updated each cycle
 core_y = get_core_y();
 int angle; // direction process is pointing
- // angles are in integer degrees from 0 to 8192, with 0 being right,
- // 2048 down, 4096 left and 6144 (or -2048) up.
+// angles are in integer degrees from 0 to 8192, with 0 being right,
+// 2048 down, 4096 left and 6144 (or -2048) up.
 angle = get_core_angle(); // angle is updated each cycle
 
 int mode; // what is the process doing? (should be one of the MODE enums)
@@ -83,275 +75,252 @@ int circle_rotation; // direction to circle the target in (should be 1024 for cl
 int circle_distance; // distance to maintain from the centre of the circle
 
 int front_attack_primary; // is set to 1 if forward directional attack objects are attacking
- // the primary target (e.g. target selected by command). Set to 0 if the objects are available for autonomous fire.
+// the primary target (e.g. target selected by command). Set to 0 if the objects are available for autonomous fire.
 int target_component; // target component for an attack command (allows user to
- // target specific components)
+// target specific components)
 
 int scan_result; // used to hold the results of a scan of nearby processes
 
 int self_destruct_primed; // counter for confirming self-destruct command (ctrl-right-click on self)
 int initialised; // set to 1 after initialisation code below run the first time
 
-if (!initialised)
-{
-   // initialisation code goes here (not all autocoded processes have initialisation code)
-  initialised = 1;
-  attack_mode(0); // attack objects (if present) will all fire together
-  // move the process forward a bit to stop it obstructing the next process to be built
-  mode = MODE_MOVE;
-  move_x = core_x + cos(angle, 300);
-  move_y = core_y + sin(angle, 300);
+if (!initialised) {
+	// initialisation code goes here (not all autocoded processes have initialisation code)
+	initialised = 1;
+	attack_mode(0); // attack objects (if present) will all fire together
+	// move the process forward a bit to stop it obstructing the next process to be built
+	mode = MODE_MOVE;
+	move_x = core_x + cos(angle, 300);
+	move_y = core_y + sin(angle, 300);
 }
 
 int verbose; // if 1, process will print various things to the console
 
-if (check_selected_single()) // returns 1 if the user has selected this process (and no other processes)
-{
-  if (!verbose) printf("\nProcess selected.");
-  verbose = 1;
-  set_debug_mode(1); // 1 means errors for this process will be printed to the console. Resets to 0 each cycle
+// returns 1 if the user has selected this process (and no other processes)
+if (check_selected_single()) {
+	if (!verbose)
+		printf("\nProcess selected.");
+	verbose = 1;
+	set_debug_mode(1); // 1 means errors for this process will be printed to the console. Resets to 0 each cycle
+} else {
+	verbose = 0;
 }
-  else
-    verbose = 0;
-
 
 // Accept commands from user
-if (check_new_command() == 1) // returns 1 if a command has been given
-{
-  switch(get_command_type()) // get_command_type() returns the type of command given
-  {
-    case COM_LOCATION:
-    case COM_DATA_WELL: // this process can't harvest, so treat data well commands as location commands
-      move_x = get_command_x(); // get_command_x() and ...y() return the target location of the command
-      move_y = get_command_y();
-      if (get_command_ctrl() == 0) // returns 1 if control was pressed when the command was given
-      {
-        mode = MODE_MOVE;
-        if (verbose) printf("\nMoving.");
-      }
-        else
-        {
-          mode = MODE_MOVE_ATTACK; // will attack anything found along the way
-          if (verbose) printf("\nAttack-moving.");
-        }
-      break;
-    
-    case COM_TARGET:
-      get_command_target(TARGET_MAIN); // writes the target of the command to address TARGET_MAIN in targetting memory
-       // (targetting memory stores the target and allows the process to examine it if it's in scanning range
-       //  of any friendly process)
-      mode = MODE_ATTACK;
-      target_x = get_command_x();
-      target_y = get_command_y();
-      target_component = get_command_target_component(); // allows user to target a specific component
-      if (verbose) printf("\nAttacking.");
-      break;
-    
-    case COM_FRIEND:
-      get_command_target(TARGET_GUARD); // writes the target of the command to address TARGET_GUARD in targetting memory
-       // (targetting memory stores the target and allows the process to examine it if it's in scanning range)
-      if (get_command_ctrl() && process[TARGET_GUARD].get_core_x() == get_core_x() && process[TARGET_GUARD].get_core_y() == get_core_y())
-      {
-        if (self_destruct_primed > 0)
-        {
-          printf("\nTerminating.");
-          terminate; // this causes the process to self-destruct
-        }
-        printf("\nSelf destruct primed.");
-        printf("\nRepeat command (ctrl-right-click self) to confirm.");
-        self_destruct_primed = 20;
-        break;
-      }
-      mode = MODE_GUARD;
-      if (verbose) printf("\nGuarding.");
-      break;
-    
-    default:
-      if (verbose) printf("\nUnrecognised command.");
-      break;
+if (check_new_command() == 1) {
+	switch(get_command_type()) {
+	case COM_LOCATION:
+	case COM_DATA_WELL: // this process can't harvest, so treat data well commands as location commands
+		move_x = get_command_x(); // get_command_x() and ...y() return the target location of the command
+		move_y = get_command_y();
+		// returns 1 if control was pressed when the command was given
+		if (get_command_ctrl() == 0) {
+			mode = MODE_MOVE;
+			if (verbose)
+				printf("\nMoving.");
+		} else {
+			mode = MODE_MOVE_ATTACK; // will attack anything found along the way
+			if (verbose)
+				printf("\nAttack-moving.");
+		}
+		break;
+	case COM_TARGET:
+		get_command_target(TARGET_MAIN); // writes the target of the command to address TARGET_MAIN in targetting memory
+		// (targetting memory stores the target and allows the process to examine it if it's in scanning range
+		//  of any friendly process)
+		mode = MODE_ATTACK;
+		target_x = get_command_x();
+		target_y = get_command_y();
+		target_component = get_command_target_component(); // allows user to target a specific component
+		if (verbose)
+			printf("\nAttacking.");
+		break;
+	case COM_FRIEND:
+		get_command_target(TARGET_GUARD); // writes the target of the command to address TARGET_GUARD in targetting memory
+		// (targetting memory stores the target and allows the process to examine it if it's in scanning range)
+		if (get_command_ctrl() &&
+			process[TARGET_GUARD].get_core_x() == get_core_x() &&
+			process[TARGET_GUARD].get_core_y() == get_core_y()) {
+			if (self_destruct_primed > 0) {
+				printf("\nTerminating.");
+				terminate; // this causes the process to self-destruct
+			}
+			printf("\nSelf destruct primed.");
+			printf("\nRepeat command (ctrl-right-click self) to confirm.");
+			self_destruct_primed = 20;
+			break;
+		}
+		mode = MODE_GUARD;
+		if (verbose)
+			printf("\nGuarding.");
+		break;
+	default:
+		if (verbose)
+			printf("\nUnrecognised command.");
+		break;
   
-  } // end of command type switch
-} // end of new command code
-
-
-if (self_destruct_primed > 0)
-{
-  self_destruct_primed --;
-  if (self_destruct_primed == 0
-   && verbose)
-    printf("\nSelf destruct cancelled.");
+	}
 }
 
+if (self_destruct_primed > 0) {
+	self_destruct_primed --;
+	if (self_destruct_primed == 0 && verbose)
+		printf("\nSelf destruct cancelled.");
+}
 
 front_attack_primary = 0; // this will be set to 1 if front attack is attacking the main target
 
 
 // What the process does next depends on its current mode
-switch(mode)
-{
-  
-  case MODE_IDLE:
-    auto_move.set_power(0); // turn off all objects in the move class
-    // now check for nearby hostile processes
-    scan_result = scan_for_threat(0, 0, TARGET_MAIN); // scan_for_threat finds the hostile process nearest to the scan centre,
-     // and saves it in the process' targetting memory.
-     // (parameters are: (x offset of scan centre from core, y offset, targetting memory address))
-    if (scan_result != 0)
-    {
-      mode = MODE_ATTACK_FOUND; // later code means that process will attack target in targetting memory 0
-      target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
-      target_y = process[TARGET_MAIN].get_core_y();
-      target_component = 0; // attack the core
-      saved_mode = MODE_IDLE; // when leaving MODE_ATTACK_FOUND, will return to this mode
-      if (verbose) printf("\nTarget found; attacking.");
-    }
-    break;
-  
-  case MODE_MOVE_ATTACK:
-  // check for nearby hostile processes
-    scan_result = scan_for_threat(0, 0, TARGET_MAIN); // scan_for_threat finds the hostile process nearest to the scan centre,
-     // and saves it in the process' targetting memory.
-     // (parameters are: (x offset of scan centre from core, y offset, targetting memory address))
-    if (scan_result != 0)
-    {
-      mode = MODE_ATTACK_FOUND; // later code means that process will attack target in targetting memory 0
-      target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
-      target_y = process[TARGET_MAIN].get_core_y();
-      target_component = 0; // attack the core
-      saved_mode = MODE_MOVE_ATTACK; // when leaving MODE_ATTACK_FOUND, will return to this mode
-      if (verbose) printf("\nTarget found - attacking.");
-      break;
-    }
-  // fall through to MODE_MOVE case...
-  
-  case MODE_MOVE:
-  // stop moving when within 255 pixels of target (can change to higher or lower values if needed)
-    if (distance_from_xy_less(move_x, move_y, 255))
-    {
-      clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
-       //  this moves the queue forward so that check_new_command() will return 1 next cycle.
-      mode = MODE_IDLE;
-      if (verbose) printf("\nReached destination.");
-    }
-      else
-        auto_move.move_to(move_x, move_y); // calls move_to for all objects in the move class
-    break;
-  
-  case MODE_ATTACK_FOUND:
-  // Attack target as long as it's visible.
-  // If target lost or destroyed, go back to previous action.
-    // Now see whether the commanded target is visible:
-    //  (targets are visible if within scanning range of any friendly process)
-    if (!process[TARGET_MAIN].visible()) // returns zero if not target visible or doesn't exist
-    {
-      auto_move.move_to(target_x, target_y); // calls move_to for all objects in the move class
-      if (distance_from_xy_less(target_x, target_y, 600))
-      {
-        // we should be able to see the target now, so it's either been destroyed
-        // or gone out of range.
-        mode = saved_mode; // the process goes back to what it was doing
-        if (verbose) printf("\nTarget not detected.");
-        break;
-      }
-    }
-      else
-      {
-        target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
-        target_y = process[TARGET_MAIN].get_core_y();
-        auto_move.approach_target(TARGET_MAIN,target_component,700);
-         // approach_target() approaches a target to within a certain distance (700 in this case).
-         //  if the process has retro move objects it will use them to maintain the distance.
-         // Parameters are:
-         //  - target's address in targetting memory
-         //  - component of target process to attack
-         //  - stand-off distance (in pixels)
-        if (distance_from_xy_less(target_x, target_y, 1000))
-        {
-          auto_att_fwd.fire_at(TARGET_MAIN,target_component); // Calls fire_at() on all objects in the forward directional attack class.
-           // TARGET_MAIN indicates that the target is in targetting memory address TARGET_MAIN.
-           // target_component is the component to fire at (can be set by user's command; defaults to 0 (attack core)).
-           // fire_at() rotates directional attack objects towards the target (with basic leading) and fires.
-          front_attack_primary = 1; // this means the forward directional attack class will not try to find its own target.
-        }
-      }
-    break;
-  
-  case MODE_ATTACK:
-  // Attack target identified by user command
-    // Now see whether the commanded target is visible:
-    //  (targets are visible if within scanning range of any friendly process)
-    if (!process[TARGET_MAIN].visible()) // returns zero if not target visible or doesn't exist
-    {
-      auto_move.move_to(target_x, target_y); // calls move_to for all objects in the move class
-      if (distance_from_xy_less(target_x, target_y, 600))
-      {
-        // we should be able to see the target now, so it's either been destroyed
-        // or gone out of range.
-        mode = saved_mode; // the process goes back to what it was doing
-        if (verbose) printf("\nTarget not detected.");
-        break;
-      }
-    }
-      else
-      {
-        target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
-        target_y = process[TARGET_MAIN].get_core_y();
-        auto_move.approach_target(TARGET_MAIN,target_component,700);
-         // approach_target() approaches a target to within a certain distance (700 in this case).
-         //  if the process has retro move objects it will use them to maintain the distance.
-         // Parameters are:
-         //  - target's address in targetting memory
-         //  - component of target process to attack
-         //  - stand-off distance (in pixels)
-        if (distance_from_xy_less(target_x, target_y, 1000))
-        {
-          auto_att_fwd.fire_at(TARGET_MAIN,target_component); // Calls fire_at() on all objects in the forward directional attack class.
-           // TARGET_MAIN indicates that the target is in targetting memory address TARGET_MAIN.
-           // target_component is the component to fire at (can be set by user's command; defaults to 0 (attack core)).
-           // fire_at() rotates directional attack objects towards the target (with basic leading) and fires.
-          front_attack_primary = 1; // this means the forward directional attack class will not try to find its own target.
-        }
-      }
-    break;
-  
-  case MODE_GUARD:
-  // Move in circle around friendly target identified by user command
-  //  and attack any enemies that come near
-    if (process[TARGET_GUARD].visible()) // returns 1 if target visible. Always returns 1 for a friendly target, if it exists.
-    {
-      // check for nearby hostile processes
-      scan_result = scan_for_threat(0, 0, TARGET_MAIN); // scan_for_threat finds the hostile process nearest to the scan centre,
-       // and saves it in the process' targetting memory.
-       // (parameters are: (x offset of scan centre from core, y offset, targetting memory address))
-      if (scan_result != 0)
-      {
-        mode = MODE_ATTACK_FOUND; // later code means that process will attack target in targetting memory 0
-        target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
-        target_y = process[TARGET_MAIN].get_core_y();
-        target_component = 0; // attack the core
-        saved_mode = MODE_GUARD; // when leaving MODE_ATTACK_FOUND, will return to this mode
-        if (verbose) printf("\nTarget found - attacking.");
-        break;
-      }
-      // Now call the circle_around_target subroutine to make this process circle the guarded process
-      circle_target = TARGET_GUARD; // circle_target is the process at the centre of the circle (here it's the process being guarded)
-      circle_rotation = 1024; // the process will aim 1024 angle units (45 degrees) around the circle, clockwise.
-      circle_distance = 700; // the process will try to stay this far from the centre of the circle
-      gosub circle_around_target; // the circle_around_target subroutine is below, near the end of the code
-      break;
-    }
-    // guard target must have been destroyed. Go back to idle mode and check for new commands.
-    clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
-     //  this moves the queue forward so that check_new_command() will return 1 next cycle.
-    mode = MODE_IDLE;
-    if (verbose) printf("\nGuard target lost.");
-    break;
+switch(mode) {
+	case MODE_IDLE:
+		auto_move.set_power(0); // turn off all objects in the move class
+		// now check for nearby hostile processes
+		scan_result = scan_for_threat(0, 0, TARGET_MAIN); // scan_for_threat finds the hostile process nearest to the scan centre,
+		// and saves it in the process' targetting memory.
+		// (parameters are: (x offset of scan centre from core, y offset, targetting memory address))
+		if (scan_result != 0) {
+			mode = MODE_ATTACK_FOUND; // later code means that process will attack target in targetting memory 0
+			target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
+			target_y = process[TARGET_MAIN].get_core_y();
+			target_component = 0; // attack the core
+			saved_mode = MODE_IDLE; // when leaving MODE_ATTACK_FOUND, will return to this mode
+			if (verbose)
+				printf("\nTarget found; attacking.");
+		}
+		break;
+	case MODE_MOVE_ATTACK:
+		// check for nearby hostile processes
+		scan_result = scan_for_threat(0, 0, TARGET_MAIN); // scan_for_threat finds the hostile process nearest to the scan centre,
+		// and saves it in the process' targetting memory.
+		// (parameters are: (x offset of scan centre from core, y offset, targetting memory address))
+		if (scan_result != 0) {
+			mode = MODE_ATTACK_FOUND; // later code means that process will attack target in targetting memory 0
+			target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
+			target_y = process[TARGET_MAIN].get_core_y();
+			target_component = 0; // attack the core
+			saved_mode = MODE_MOVE_ATTACK; // when leaving MODE_ATTACK_FOUND, will return to this mode
+			if (verbose)
+				printf("\nTarget found - attacking.");
+			break;
+		}
+		// fall through to MODE_MOVE case...
+	case MODE_MOVE:
+		// stop moving when within 255 pixels of target (can change to higher or lower values if needed)
+		if (distance_from_xy_less(move_x, move_y, 255)) {
+			clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
+			//  this moves the queue forward so that check_new_command() will return 1 next cycle.
+			mode = MODE_IDLE;
+			if (verbose)
+				printf("\nReached destination.");
+		} else {
+			auto_move.move_to(move_x, move_y); // calls move_to for all objects in the move class
+		}
+		break;
+	case MODE_ATTACK_FOUND:
+		// Attack target as long as it's visible.
+		// If target lost or destroyed, go back to previous action.
+		// Now see whether the commanded target is visible:
+		//  (targets are visible if within scanning range of any friendly process)
+		if (!process[TARGET_MAIN].visible()) {
+			auto_move.move_to(target_x, target_y); // calls move_to for all objects in the move class
+			if (distance_from_xy_less(target_x, target_y, 600)) {
+				// we should be able to see the target now, so it's either been destroyed
+				// or gone out of range.
+				mode = saved_mode; // the process goes back to what it was doing
+				if (verbose)
+					printf("\nTarget not detected.");
+				break;
+			}
+		} else {
+			target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
+			target_y = process[TARGET_MAIN].get_core_y();
+			auto_move.approach_target(TARGET_MAIN,target_component,700);
+			// approach_target() approaches a target to within a certain distance (700 in this case).
+			//  if the process has retro move objects it will use them to maintain the distance.
+			// Parameters are:
+			//  - target's address in targetting memory
+			//  - component of target process to attack
+			//  - stand-off distance (in pixels)
+			if (distance_from_xy_less(target_x, target_y, 1000)) {
+				auto_att_fwd.fire_at(TARGET_MAIN,target_component); // Calls fire_at() on all objects in the forward directional attack class.
+				// TARGET_MAIN indicates that the target is in targetting memory address TARGET_MAIN.
+				// target_component is the component to fire at (can be set by user's command; defaults to 0 (attack core)).
+				// fire_at() rotates directional attack objects towards the target (with basic leading) and fires.
+				front_attack_primary = 1; // this means the forward directional attack class will not try to find its own target.
+			}
+		}
+		break;
+	case MODE_ATTACK:
+		// Attack target identified by user command
+		// Now see whether the commanded target is visible:
+		//  (targets are visible if within scanning range of any friendly process)
+		if (!process[TARGET_MAIN].visible()) {
+			auto_move.move_to(target_x, target_y); // calls move_to for all objects in the move class
+			if (distance_from_xy_less(target_x, target_y, 600)) {
+				// we should be able to see the target now, so it's either been destroyed
+				// or gone out of range.
+				mode = saved_mode; // the process goes back to what it was doing
+				if (verbose)
+					printf("\nTarget not detected.");
+				break;
+			}
+		} else {
+			target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
+			target_y = process[TARGET_MAIN].get_core_y();
+			auto_move.approach_target(TARGET_MAIN,target_component,700);
+			// approach_target() approaches a target to within a certain distance (700 in this case).
+			//  if the process has retro move objects it will use them to maintain the distance.
+			// Parameters are:
+			//  - target's address in targetting memory
+			//  - component of target process to attack
+			//  - stand-off distance (in pixels)
+			if (distance_from_xy_less(target_x, target_y, 1000)) {
+				auto_att_fwd.fire_at(TARGET_MAIN,target_component); // Calls fire_at() on all objects in the forward directional attack class.
+				// TARGET_MAIN indicates that the target is in targetting memory address TARGET_MAIN.
+				// target_component is the component to fire at (can be set by user's command; defaults to 0 (attack core)).
+				// fire_at() rotates directional attack objects towards the target (with basic leading) and fires.
+				front_attack_primary = 1; // this means the forward directional attack class will not try to find its own target.
+			}
+		}
+		break;
+	case MODE_GUARD:
+		// Move in circle around friendly target identified by user command
+		//  and attack any enemies that come near
+		if (process[TARGET_GUARD].visible()) {
+			// check for nearby hostile processes
+			scan_result = scan_for_threat(0, 0, TARGET_MAIN); // scan_for_threat finds the hostile process nearest to the scan centre,
+			// and saves it in the process' targetting memory.
+			// (parameters are: (x offset of scan centre from core, y offset, targetting memory address))
+			if (scan_result != 0) {
+				mode = MODE_ATTACK_FOUND; // later code means that process will attack target in targetting memory 0
+				target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
+				target_y = process[TARGET_MAIN].get_core_y();
+				target_component = 0; // attack the core
+				saved_mode = MODE_GUARD; // when leaving MODE_ATTACK_FOUND, will return to this mode
+				if (verbose)
+					printf("\nTarget found - attacking.");
+				break;
+			}
+			// Now call the circle_around_target subroutine to make this process circle the guarded process
+			circle_target = TARGET_GUARD; // circle_target is the process at the centre of the circle (here it's the process being guarded)
+			circle_rotation = 1024; // the process will aim 1024 angle units (45 degrees) around the circle, clockwise.
+			circle_distance = 700; // the process will try to stay this far from the centre of the circle
+			gosub circle_around_target; // the circle_around_target subroutine is below, near the end of the code
+			break;
+		}
+		// guard target must have been destroyed. Go back to idle mode and check for new commands.
+		clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
+		//  this moves the queue forward so that check_new_command() will return 1 next cycle.
+		mode = MODE_IDLE;
+		if (verbose)
+			printf("\nGuard target lost.");
+		break;
+}
 
-} // end of mode switch
-
-if (front_attack_primary == 0) // is 1 if the forward attack objects are attacking the main target
-{
-  auto_att_fwd.attack_scan(0, 400, TARGET_FRONT);
+// is 1 if the forward attack objects are attacking the main target
+if (front_attack_primary == 0) {
+	auto_att_fwd.attack_scan(0, 400, TARGET_FRONT);
 }
 
 exit; // stops execution, until the next cycle
@@ -359,21 +328,20 @@ exit; // stops execution, until the next cycle
 // if there are any subroutines (called by gosub statements), they go here
 
 
-
 circle_around_target: // this is a label for gosub statements
-  // this subroutine makes the process circle around a target.
-  // before this subroutine was called, circle_target should have been set to
-  //  the target that the process will circle around. The target should be visible.
-  // And circle_rotation should have been set to 1024 (clockwise - for guard commands)
-  //  or -1024 (anticlockwise - for attack commands)
-  int angle_to_circle_target, circle_move_x, circle_move_y;
-  angle_to_circle_target = process[circle_target].target_angle();
-  angle_to_circle_target += circle_rotation; // this will lead the process in a circle around the target
-  circle_move_x = process[circle_target].get_core_x() // location of target
-                  + (process[circle_target].get_core_speed_x() * 10) // if the target is moving, aim for a point a little ahead of it
-                  - cos(angle_to_circle_target, circle_distance); // work out the radius of the circle around the target
-  circle_move_y = process[circle_target].get_core_y()
-                  + (process[circle_target].get_core_speed_y() * 10)
-                  - sin(angle_to_circle_target, circle_distance);
-  auto_move.move_to(circle_move_x, circle_move_y);
-  return; // returns to the statement immediately after the gosub
+	// this subroutine makes the process circle around a target.
+	// before this subroutine was called, circle_target should have been set to
+	//  the target that the process will circle around. The target should be visible.
+	// And circle_rotation should have been set to 1024 (clockwise - for guard commands)
+	//  or -1024 (anticlockwise - for attack commands)
+	int angle_to_circle_target, circle_move_x, circle_move_y;
+	angle_to_circle_target = process[circle_target].target_angle();
+	angle_to_circle_target += circle_rotation; // this will lead the process in a circle around the target
+	circle_move_x = process[circle_target].get_core_x() // location of target
+		+ (process[circle_target].get_core_speed_x() * 10) // if the target is moving, aim for a point a little ahead of it
+		- cos(angle_to_circle_target, circle_distance); // work out the radius of the circle around the target
+	circle_move_y = process[circle_target].get_core_y()
+		+ (process[circle_target].get_core_speed_y() * 10)
+		- sin(angle_to_circle_target, circle_distance);
+	auto_move.move_to(circle_move_x, circle_move_y);
+	return; // returns to the statement immediately after the gosub

--- a/bin/proc/cm_base.c
+++ b/bin/proc/cm_base.c
@@ -1,5 +1,3 @@
-
-
 #process "base"
 
 // This process has objects with the following auto classes:
@@ -18,11 +16,11 @@ class auto_att_spike;
 class auto_stability;
 
 core_static_pent, 0, 
-  {object_build, 0},
-  {object_repair, 0},
-  {object_allocate:auto_allocate, 0},
-  {object_storage, 0},
-  {object_harvest:auto_harvest, 0},
+	{object_build, 0},
+	{object_repair, 0},
+	{object_allocate:auto_allocate, 0},
+	{object_storage, 0},
+	{object_harvest:auto_harvest, 0},
 #code
 
 
@@ -31,19 +29,19 @@ core_static_pent, 0,
 // Process AI modes (these reflect the capabilities of the process)
 enum
 {
-  MODE_IDLE, // process isn't doing anything ongoing
-  MODES
+	MODE_IDLE, // process isn't doing anything ongoing
+	MODES
 };
 
-// Commands that the user may give the process
-// (these are fixed and should not be changed, although not all processes accept all commands)
+// Commands that the user may give the process (these are fixed and
+// should not be changed, although not all processes accept all commands)
 enum
 {
-  COM_NONE, // no command
-  COM_LOCATION, // user has right-clicked somewhere on the display or map
-  COM_TARGET, // user has right-clicked on an enemy process
-  COM_FRIEND, // user has right-clicked on a friendly process
-  COM_DATA_WELL // user has right-clicked on a data well
+	COM_NONE, // no command
+	COM_LOCATION, // user has right-clicked somewhere on the display or map
+	COM_TARGET, // user has right-clicked on an enemy process
+	COM_FRIEND, // user has right-clicked on a friendly process
+	COM_DATA_WELL // user has right-clicked on a data well
 };
 
 // Targetting information
@@ -51,127 +49,126 @@ enum
 // The following enums are used as indices in the process' targetting memory
 enum
 {
-  TARGET_PARENT, // a newly built process starts with its builder in address 0
-  TARGET_BUILT, // processes built by this process
-  TARGET_ALLOCATOR, // process that this process will return to when finished harvesting
-  TARGET_SELF_CHECK, // check against self for self-destruct commands
+	TARGET_PARENT, // a newly built process starts with its builder in address 0
+	TARGET_BUILT, // processes built by this process
+	TARGET_ALLOCATOR, // process that this process will return to when finished harvesting
+	TARGET_SELF_CHECK, // check against self for self-destruct commands
 };
 
 
 // Variable declaration and initialisation
-//  (note that declaration and initialisation cannot be combined)
-//  (also, variables retain their values between execution cycles)
+// (note that declaration and initialisation cannot be combined)
+// (also, variables retain their values between execution cycles)
 int core_x, core_y; // location of core
 core_x = get_core_x(); // location is updated each cycle
 core_y = get_core_y();
-int angle; // direction process is pointing
- // angles are in integer degrees from 0 to 8192, with 0 being right,
- // 2048 down, 4096 left and 6144 (or -2048) up.
+int angle; // direction process is pointing angles are in integer
+// degrees from 0 to 8192, with 0 being right, 2048
+// down, 4096 left and 6144 (or -2048) up.
+
 angle = get_core_angle(); // angle is updated each cycle
 
 int mode; // what is the process doing? (should be one of the MODE enums)
 
-int target_component; // target component for an attack command (allows user to
- // target specific components)
+int target_component;// target component for an attack command (allows user to
+// target specific components)
 
 int scan_result; // used to hold the results of a scan of nearby processes
 
-int self_destruct_primed; // counter for confirming self-destruct command (ctrl-right-click on self)
+// counter for confirming self-destruct command (ctrl-right-click on self)
+int self_destruct_primed;
 
 // builder variables
 int build_result; // build result code (returned by build call)
 int initialised; // set to 1 after initialisation code below run the first time
 
-if (!initialised)
-{
-   // initialisation code goes here (not all autocoded processes have initialisation code)
-  initialised = 1;
-  attack_mode(0); // attack objects (if present) will all fire together
+if (!initialised) {
+	// initialisation code goes here (not all autocoded
+	// processes have initialisation code)
+	initialised = 1;
+	attack_mode(0); // attack objects (if present) will all fire together
 }
 
 int verbose; // if 1, process will print various things to the console
 
-if (check_selected_single()) // returns 1 if the user has selected this process (and no other processes)
-{
-  if (!verbose) printf("\nProcess selected.");
-  verbose = 1;
-  set_debug_mode(1); // 1 means errors for this process will be printed to the console. Resets to 0 each cycle
+// returns 1 if the user has selected this process (and no other processes)
+if (check_selected_single()) {
+	if (!verbose) printf("\nProcess selected.");
+	verbose = 1;
+	// 1 means errors for this process will be printed to the console.
+	// Resets to 0 each cycle.
+	set_debug_mode(1); 
+} else {
+	verbose = 0;
 }
-  else
-    verbose = 0;
-
 
 // Accept commands from user
-if (check_new_command() == 1) // returns 1 if a command has been given
-{
-  switch(get_command_type()) // get_command_type() returns the type of command given
-  {
-    case COM_LOCATION:
-    case COM_DATA_WELL: // this process can't harvest, so treat data well commands as location commands
-      if (verbose) printf("\nLocation command will be sent to new processes.");
-      break;
-    
-    case COM_TARGET:
-      if (verbose) printf("\nTarget command will be sent to new processes.");
-      break;
-    
-    case COM_FRIEND:
-      get_command_target(TARGET_SELF_CHECK); // writes the target of the command to address TARGET_SELF_CHECK in targetting memory
-      if (get_command_ctrl() && process[TARGET_SELF_CHECK].get_core_x() == get_core_x() && process[TARGET_SELF_CHECK].get_core_y() == get_core_y())
-      {
-        if (self_destruct_primed > 0)
-        {
-          printf("\nTerminating.");
-          terminate; // this causes the process to self-destruct
-        }
-        printf("\nSelf destruct primed.");
-        printf("\nRepeat command (ctrl-right-click self) to confirm.");
-        self_destruct_primed = 20;
-        break;
-      }
-      if (verbose) printf("\nFriendly target command will be sent to new processes.");
-      break;
-    
-    default:
-      if (verbose) printf("\nUnrecognised command.");
-      break;
+if (check_new_command() == 1) {
+	switch(get_command_type()) {
+	case COM_LOCATION:
+	// this process can't harvest, so treat data well commands as
+	// location commands
+	case COM_DATA_WELL:
+		if (verbose)
+			printf("\nLocation command will be sent to new processes.");
+		break;
+	case COM_TARGET:
+		if (verbose)
+			printf("\nTarget command will be sent to new processes.");
+		break;
+	case COM_FRIEND:
+		// writes the target of the command to address
+		// TARGET_SELF_CHECK in targetting memory
+		get_command_target(TARGET_SELF_CHECK); 
+		if (get_command_ctrl() &&
+			process[TARGET_SELF_CHECK].get_core_x() == get_core_x() &&
+			process[TARGET_SELF_CHECK].get_core_y() == get_core_y()) {
+			if (self_destruct_primed > 0) {
+				printf("\nTerminating.");
+				terminate; // this causes the process to self-destruct
+			}
+			printf("\nSelf destruct primed.");
+			printf("\nRepeat command (ctrl-right-click self) to confirm.");
+			self_destruct_primed = 20;
+			break;
+		}
+		if (verbose)
+			printf("\nFriendly target command will be sent to new processes.");
+		break;
+	default:
+		if (verbose)
+			printf("\nUnrecognised command.");
+		break;
   
-  } // end of command type switch
-} // end of new command code
+	}
+}
 
 
-if (self_destruct_primed > 0)
-{
-  self_destruct_primed --;
-  if (self_destruct_primed == 0
-   && verbose)
-    printf("\nSelf destruct cancelled.");
+if (self_destruct_primed > 0) {
+	self_destruct_primed --;
+	if (self_destruct_primed == 0 && verbose)
+		printf("\nSelf destruct cancelled.");
 }
 
 
 // Now try to build a new process from the build queue.
-// This only does anything if a build command for this process is at the front of the queue.
-// Otherwise, it will just fail.
-if (build_from_queue(TARGET_BUILT) == 1) // returns 1 on success
-  copy_commands(TARGET_BUILT); // copies builder's command queue to newly built process
-
-
-
+// This only does anything if a build command for this process is at the
+// front of the queue. Otherwise, it will just fail.
+if (build_from_queue(TARGET_BUILT) == 1)
+	// copies builder's command queue to newly built process
+	copy_commands(TARGET_BUILT); 
 
 auto_harvest.gather_data();
-
 
 auto_allocate.allocate_data(4); // actually I think the maximum is 2
 
 
 // What the process does next depends on its current mode
-switch(mode)
-{
-  
-  case MODE_IDLE:
-    break;
+switch(mode) {
+case MODE_IDLE:
+	break;
 
-} // end of mode switch
+}
 
 restore_self(); // tries to restore any destroyed components
 
@@ -179,4 +176,4 @@ repair_self(); // tries to repair any damaged components
 
 exit; // stops execution, until the next cycle
 
-// if there are any subroutines (called by gosub statements), they go here
+// any subroutines (called by gosub statements) go here

--- a/bin/proc/cm_command.c
+++ b/bin/proc/cm_command.c
@@ -1,5 +1,3 @@
-
-
 #process "commander"
 
 // This process has objects with the following auto classes:
@@ -18,103 +16,96 @@ class auto_allocate;
 class auto_stability;
 
 core_pent_A, 4096, 
-  {object_repair, 0},
-  {object_downlink, -1015, 
-    {component_fork, // component 1
-      {object_uplink, 0},
-      {object_downlink, -527, 
-        {component_cap, // component 2
-          {object_uplink, 0},
-          {object_move:auto_move, 2048},
-          {object_move:auto_move, 776},
-          {object_move:auto_move, -239},
-        }
-      },
-      {object_pulse:auto_att_back, 0},
-    }
-  },
-  {object_downlink, 277, 
-    {component_prong, // component 3
-      {object_pulse:auto_att_fwd, 0},
-      {object_none, 0},
-      {object_pulse:auto_att_left, -711},
-      {object_uplink, 0},
-    }
-  },
-  {object_downlink, -277, 
-    {component_prong, // component 4
-      {object_none, 0},
-      {object_pulse:auto_att_fwd, 0},
-      {object_uplink, 0},
-      {object_pulse:auto_att_right, 711},
-    }
-  },
-  {object_downlink, 1015, 
-    {component_fork, // component 5
-      {object_uplink, 0},
-      {object_pulse:auto_att_back, 0},
-      {object_downlink, 527, 
-        {component_cap, // component 6
-          {object_move:auto_move, 239},
-          {object_move:auto_move, -776},
-          {object_move:auto_move, -2048},
-          {object_uplink, 0},
-        }
-      },
-    }
-  },
+	{object_repair, 0},
+	{object_downlink, -1015, 
+		{component_fork, // component 1
+			{object_uplink, 0},
+			{object_downlink, -527, 
+				{component_cap, // component 2
+					{object_uplink, 0},
+					{object_move:auto_move, 2048},
+					{object_move:auto_move, 776},
+					{object_move:auto_move, -239},
+				}
+			},
+			{object_pulse:auto_att_back, 0},
+		}
+	},
+	{object_downlink, 277, 
+		{component_prong, // component 3
+			{object_pulse:auto_att_fwd, 0},
+			{object_none, 0},
+			{object_pulse:auto_att_left, -711},
+			{object_uplink, 0},
+		}
+	},
+	{object_downlink, -277, 
+		{component_prong, // component 4
+			{object_none, 0},
+			{object_pulse:auto_att_fwd, 0},
+			{object_uplink, 0},
+			{object_pulse:auto_att_right, 711},
+		}
+	},
+	{object_downlink, 1015, 
+	{component_fork, // component 5
+			{object_uplink, 0},
+			{object_pulse:auto_att_back, 0},
+			{object_downlink, 527, 
+				{component_cap, // component 6
+					{object_move:auto_move, 239},
+					{object_move:auto_move, -776},
+				{object_move:auto_move, -2048},
+					{object_uplink, 0},
+				}
+			},
+		}
+	},
 #code
 
-
-
-
 // Process AI modes (these reflect the capabilities of the process)
-enum
-{
-  MODE_IDLE, // process isn't doing anything ongoing
-  MODE_MOVE, // process is moving to target_x, target_y
-  MODE_MOVE_ATTACK, // process is moving, but will attack anything it finds along the way
-  MODE_ATTACK, // process is attacking a target it was commanded to attack
-  MODE_ATTACK_FOUND, // process is attacking a target it found itself
-  MODE_GUARD, // process is circling a friendly process
-  MODES
+enum {
+	MODE_IDLE, // process isn't doing anything ongoing
+	MODE_MOVE, // process is moving to target_x, target_y
+	MODE_MOVE_ATTACK, // process is moving, but will attack anything it finds along the way
+	MODE_ATTACK, // process is attacking a target it was commanded to attack
+	MODE_ATTACK_FOUND, // process is attacking a target it found itself
+	MODE_GUARD, // process is circling a friendly process
+	MODES
 };
 
 // Commands that the user may give the process
 // (these are fixed and should not be changed, although not all processes accept all commands)
-enum
-{
-  COM_NONE, // no command
-  COM_LOCATION, // user has right-clicked somewhere on the display or map
-  COM_TARGET, // user has right-clicked on an enemy process
-  COM_FRIEND, // user has right-clicked on a friendly process
-  COM_DATA_WELL // user has right-clicked on a data well
+enum {
+	COM_NONE, // no command
+	COM_LOCATION, // user has right-clicked somewhere on the display or map
+	COM_TARGET, // user has right-clicked on an enemy process
+	COM_FRIEND, // user has right-clicked on a friendly process
+	COM_DATA_WELL // user has right-clicked on a data well
 };
 
 // Targetting information
 // Targetting memory allows processes to track targets (enemy or friend)
 // The following enums are used as indices in the process' targetting memory
-enum
-{
-  TARGET_PARENT, // a newly built process starts with its builder in address 0
-  TARGET_MAIN, // main target
-  TARGET_FRONT, // target of directional forward attack
-  TARGET_LEFT, // target of directional left attack
-  TARGET_RIGHT, // target of directional right attack
-  TARGET_BACK, // target of directional backwards attack
-  TARGET_GUARD, // target of guard command
+enum {
+	TARGET_PARENT, // a newly built process starts with its builder in address 0
+	TARGET_MAIN, // main target
+	TARGET_FRONT, // target of directional forward attack
+	TARGET_LEFT, // target of directional left attack
+	TARGET_RIGHT, // target of directional right attack
+	TARGET_BACK, // target of directional backwards attack
+	TARGET_GUARD, // target of guard command
 };
 
-
 // Variable declaration and initialisation
-//  (note that declaration and initialisation cannot be combined)
-//  (also, variables retain their values between execution cycles)
+// (note that declaration and initialisation cannot be combined)
+// (also, variables retain their values between execution cycles)
 int core_x, core_y; // location of core
 core_x = get_core_x(); // location is updated each cycle
 core_y = get_core_y();
 int angle; // direction process is pointing
- // angles are in integer degrees from 0 to 8192, with 0 being right,
- // 2048 down, 4096 left and 6144 (or -2048) up.
+// angles are in integer degrees from 0 to 8192, with 0 being right,
+// 2048 down, 4096 left and 6144 (or -2048) up.
 angle = get_core_angle(); // angle is updated each cycle
 
 int mode; // what is the process doing? (should be one of the MODE enums)
@@ -127,275 +118,247 @@ int circle_rotation; // direction to circle the target in (should be 1024 for cl
 int circle_distance; // distance to maintain from the centre of the circle
 
 int front_attack_primary; // is set to 1 if forward directional attack objects are attacking
- // the primary target (e.g. target selected by command). Set to 0 if the objects are available for autonomous fire.
+// the primary target (e.g. target selected by command). Set to 0 if the objects are available for autonomous fire.
 int target_component; // target component for an attack command (allows user to
- // target specific components)
+// target specific components)
 
 int scan_result; // used to hold the results of a scan of nearby processes
 
 int self_destruct_primed; // counter for confirming self-destruct command (ctrl-right-click on self)
 int initialised; // set to 1 after initialisation code below run the first time
 
-if (!initialised)
-{
-   // initialisation code goes here (not all autocoded processes have initialisation code)
-  initialised = 1;
-  attack_mode(0); // attack objects (if present) will all fire together
-  // move the process forward a bit to stop it obstructing the next process to be built
-  mode = MODE_MOVE;
-  move_x = core_x + cos(angle, 300);
-  move_y = core_y + sin(angle, 300);
+if (!initialised) {
+	// initialisation code goes here (not all autocoded processes have initialisation code)
+	initialised = 1;
+	attack_mode(0); // attack objects (if present) will all fire together
+	// move the process forward a bit to stop it obstructing the next process to be built
+	mode = MODE_MOVE;
+	move_x = core_x + cos(angle, 300);
+	move_y = core_y + sin(angle, 300);
 }
 
 int verbose; // if 1, process will print various things to the console
 
-if (check_selected_single()) // returns 1 if the user has selected this process (and no other processes)
-{
-  if (!verbose) printf("\nProcess selected.");
-  verbose = 1;
-  set_debug_mode(1); // 1 means errors for this process will be printed to the console. Resets to 0 each cycle
+if (check_selected_single()) {
+	if (!verbose)
+		printf("\nProcess selected.");
+	verbose = 1;
+	set_debug_mode(1); // 1 means errors for this process will be printed to the console. Resets to 0 each cycle
+} else {
+	verbose = 0;
 }
-  else
-    verbose = 0;
-
 
 // Accept commands from user
-if (check_new_command() == 1) // returns 1 if a command has been given
-{
-  switch(get_command_type()) // get_command_type() returns the type of command given
-  {
-    case COM_LOCATION:
-    case COM_DATA_WELL: // this process can't harvest, so treat data well commands as location commands
-      move_x = get_command_x(); // get_command_x() and ...y() return the target location of the command
-      move_y = get_command_y();
-      if (get_command_ctrl() == 0) // returns 1 if control was pressed when the command was given
-      {
-        mode = MODE_MOVE;
-        if (verbose) printf("\nMoving.");
-      }
-        else
-        {
-          mode = MODE_MOVE_ATTACK; // will attack anything found along the way
-          if (verbose) printf("\nAttack-moving.");
-        }
-      break;
-    
-    case COM_TARGET:
-      get_command_target(TARGET_MAIN); // writes the target of the command to address TARGET_MAIN in targetting memory
-       // (targetting memory stores the target and allows the process to examine it if it's in scanning range
-       //  of any friendly process)
-      mode = MODE_ATTACK;
-      target_x = get_command_x();
-      target_y = get_command_y();
-      target_component = get_command_target_component(); // allows user to target a specific component
-      if (verbose) printf("\nAttacking.");
-      break;
-    
-    case COM_FRIEND:
-      get_command_target(TARGET_GUARD); // writes the target of the command to address TARGET_GUARD in targetting memory
-       // (targetting memory stores the target and allows the process to examine it if it's in scanning range)
-      if (get_command_ctrl() && process[TARGET_GUARD].get_core_x() == get_core_x() && process[TARGET_GUARD].get_core_y() == get_core_y())
-      {
-        if (self_destruct_primed > 0)
-        {
-          printf("\nTerminating.");
-          terminate; // this causes the process to self-destruct
-        }
-        printf("\nSelf destruct primed.");
-        printf("\nRepeat command (ctrl-right-click self) to confirm.");
-        self_destruct_primed = 20;
-        break;
-      }
-      mode = MODE_GUARD;
-      if (verbose) printf("\nGuarding.");
-      break;
-    
-    default:
-      if (verbose) printf("\nUnrecognised command.");
-      break;
-  
-  } // end of command type switch
-} // end of new command code
-
-
-if (self_destruct_primed > 0)
-{
-  self_destruct_primed --;
-  if (self_destruct_primed == 0
-   && verbose)
-    printf("\nSelf destruct cancelled.");
+if (check_new_command() == 1) {
+	switch(get_command_type()) {
+	case COM_LOCATION:
+	case COM_DATA_WELL: // this process can't harvest, so treat data well commands as location commands
+		move_x = get_command_x(); // get_command_x() and ...y() return the target location of the command
+		move_y = get_command_y();
+		if (get_command_ctrl() == 0) {// returns 1 if control was pressed when the command was given
+			mode = MODE_MOVE;
+			if (verbose)
+				printf("\nMoving.");
+		} else {
+			mode = MODE_MOVE_ATTACK; // will attack anything found along the way
+			if (verbose)
+				printf("\nAttack-moving.");
+		}
+		break;
+	case COM_TARGET:
+		get_command_target(TARGET_MAIN); // writes the target of the command to address TARGET_MAIN in targetting memory
+		// (targetting memory stores the target and allows the process to examine it if it's in scanning range
+		//  of any friendly process)
+		mode = MODE_ATTACK;
+		target_x = get_command_x();
+		target_y = get_command_y();
+		target_component = get_command_target_component(); // allows user to target a specific component
+		if (verbose)
+			printf("\nAttacking.");
+		break;
+	case COM_FRIEND:
+		get_command_target(TARGET_GUARD); // writes the target of the command to address TARGET_GUARD in targetting memory
+		// (targetting memory stores the target and allows the process to examine it if it's in scanning range)
+		if (get_command_ctrl() &&
+			process[TARGET_GUARD].get_core_x() == get_core_x() &&
+			process[TARGET_GUARD].get_core_y() == get_core_y()) {
+			if (self_destruct_primed > 0) {
+				printf("\nTerminating.");
+				terminate; // this causes the process to self-destruct
+			}
+			printf("\nSelf destruct primed.");
+			printf("\nRepeat command (ctrl-right-click self) to confirm.");
+			self_destruct_primed = 20;
+			break;
+		}
+		mode = MODE_GUARD;
+		if (verbose)
+			printf("\nGuarding.");
+		break;
+	default:
+		if (verbose)
+			printf("\nUnrecognised command.");
+		break;
+	}
 }
 
+if (self_destruct_primed > 0) {
+	self_destruct_primed --;
+	if (self_destruct_primed == 0 && verbose)
+		printf("\nSelf destruct cancelled.");
+}
 
 front_attack_primary = 0; // this will be set to 1 if front attack is attacking the main target
 
-
 // What the process does next depends on its current mode
-switch(mode)
-{
-  
-  case MODE_IDLE:
-    auto_move.set_power(0); // turn off all objects in the move class
-    // now check for nearby hostile processes
-    scan_result = scan_for_threat(0, 0, TARGET_MAIN); // scan_for_threat finds the hostile process nearest to the scan centre,
-     // and saves it in the process' targetting memory.
-     // (parameters are: (x offset of scan centre from core, y offset, targetting memory address))
-    if (scan_result != 0)
-    {
-      mode = MODE_ATTACK_FOUND; // later code means that process will attack target in targetting memory 0
-      target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
-      target_y = process[TARGET_MAIN].get_core_y();
-      target_component = 0; // attack the core
-      saved_mode = MODE_IDLE; // when leaving MODE_ATTACK_FOUND, will return to this mode
-      if (verbose) printf("\nTarget found; attacking.");
-    }
-    break;
-  
-  case MODE_MOVE_ATTACK:
-  // check for nearby hostile processes
-    scan_result = scan_for_threat(0, 0, TARGET_MAIN); // scan_for_threat finds the hostile process nearest to the scan centre,
-     // and saves it in the process' targetting memory.
-     // (parameters are: (x offset of scan centre from core, y offset, targetting memory address))
-    if (scan_result != 0)
-    {
-      mode = MODE_ATTACK_FOUND; // later code means that process will attack target in targetting memory 0
-      target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
-      target_y = process[TARGET_MAIN].get_core_y();
-      target_component = 0; // attack the core
-      saved_mode = MODE_MOVE_ATTACK; // when leaving MODE_ATTACK_FOUND, will return to this mode
-      if (verbose) printf("\nTarget found - attacking.");
-      break;
-    }
-  // fall through to MODE_MOVE case...
-  
-  case MODE_MOVE:
-  // stop moving when within 255 pixels of target (can change to higher or lower values if needed)
-    if (distance_from_xy_less(move_x, move_y, 255))
-    {
-      clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
-       //  this moves the queue forward so that check_new_command() will return 1 next cycle.
-      mode = MODE_IDLE;
-      if (verbose) printf("\nReached destination.");
-    }
-      else
-        auto_move.move_to(move_x, move_y); // calls move_to for all objects in the move class
-    break;
-  
-  case MODE_ATTACK_FOUND:
-  // Attack target as long as it's visible.
-  // If target lost or destroyed, go back to previous action.
-    // Now see whether the commanded target is visible:
-    //  (targets are visible if within scanning range of any friendly process)
-    if (!process[TARGET_MAIN].visible()) // returns zero if not target visible or doesn't exist
-    {
-      auto_move.move_to(target_x, target_y); // calls move_to for all objects in the move class
-      if (distance_from_xy_less(target_x, target_y, 600))
-      {
-        // we should be able to see the target now, so it's either been destroyed
-        // or gone out of range.
-        mode = saved_mode; // the process goes back to what it was doing
-        if (verbose) printf("\nTarget not detected.");
-        break;
-      }
-    }
-      else
-      {
-        target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
-        target_y = process[TARGET_MAIN].get_core_y();
-        auto_move.approach_target(TARGET_MAIN,target_component,700);
-         // approach_target() approaches a target to within a certain distance (700 in this case).
-         //  if the process has retro move objects it will use them to maintain the distance.
-         // Parameters are:
-         //  - target's address in targetting memory
-         //  - component of target process to attack
-         //  - stand-off distance (in pixels)
-        if (distance_from_xy_less(target_x, target_y, 1000))
-        {
-          auto_att_fwd.fire_at(TARGET_MAIN,target_component); // Calls fire_at() on all objects in the forward directional attack class.
-           // TARGET_MAIN indicates that the target is in targetting memory address TARGET_MAIN.
-           // target_component is the component to fire at (can be set by user's command; defaults to 0 (attack core)).
-           // fire_at() rotates directional attack objects towards the target (with basic leading) and fires.
-          front_attack_primary = 1; // this means the forward directional attack class will not try to find its own target.
-        }
-      }
-    break;
-  
-  case MODE_ATTACK:
-  // Attack target identified by user command
-    // Now see whether the commanded target is visible:
-    //  (targets are visible if within scanning range of any friendly process)
-    if (!process[TARGET_MAIN].visible()) // returns zero if not target visible or doesn't exist
-    {
-      auto_move.move_to(target_x, target_y); // calls move_to for all objects in the move class
-      if (distance_from_xy_less(target_x, target_y, 600))
-      {
-        // we should be able to see the target now, so it's either been destroyed
-        // or gone out of range.
-        mode = saved_mode; // the process goes back to what it was doing
-        if (verbose) printf("\nTarget not detected.");
-        break;
-      }
-    }
-      else
-      {
-        target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
-        target_y = process[TARGET_MAIN].get_core_y();
-        auto_move.approach_target(TARGET_MAIN,target_component,700);
-         // approach_target() approaches a target to within a certain distance (700 in this case).
-         //  if the process has retro move objects it will use them to maintain the distance.
-         // Parameters are:
-         //  - target's address in targetting memory
-         //  - component of target process to attack
-         //  - stand-off distance (in pixels)
-        if (distance_from_xy_less(target_x, target_y, 1000))
-        {
-          auto_att_fwd.fire_at(TARGET_MAIN,target_component); // Calls fire_at() on all objects in the forward directional attack class.
-           // TARGET_MAIN indicates that the target is in targetting memory address TARGET_MAIN.
-           // target_component is the component to fire at (can be set by user's command; defaults to 0 (attack core)).
-           // fire_at() rotates directional attack objects towards the target (with basic leading) and fires.
-          front_attack_primary = 1; // this means the forward directional attack class will not try to find its own target.
-        }
-      }
-    break;
-  
-  case MODE_GUARD:
-  // Move in circle around friendly target identified by user command
-  //  and attack any enemies that come near
-    if (process[TARGET_GUARD].visible()) // returns 1 if target visible. Always returns 1 for a friendly target, if it exists.
-    {
-      // check for nearby hostile processes
-      scan_result = scan_for_threat(0, 0, TARGET_MAIN); // scan_for_threat finds the hostile process nearest to the scan centre,
-       // and saves it in the process' targetting memory.
-       // (parameters are: (x offset of scan centre from core, y offset, targetting memory address))
-      if (scan_result != 0)
-      {
-        mode = MODE_ATTACK_FOUND; // later code means that process will attack target in targetting memory 0
-        target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
-        target_y = process[TARGET_MAIN].get_core_y();
-        target_component = 0; // attack the core
-        saved_mode = MODE_GUARD; // when leaving MODE_ATTACK_FOUND, will return to this mode
-        if (verbose) printf("\nTarget found - attacking.");
-        break;
-      }
-      // Now call the circle_around_target subroutine to make this process circle the guarded process
-      circle_target = TARGET_GUARD; // circle_target is the process at the centre of the circle (here it's the process being guarded)
-      circle_rotation = 1024; // the process will aim 1024 angle units (45 degrees) around the circle, clockwise.
-      circle_distance = 700; // the process will try to stay this far from the centre of the circle
-      gosub circle_around_target; // the circle_around_target subroutine is below, near the end of the code
-      break;
-    }
-    // guard target must have been destroyed. Go back to idle mode and check for new commands.
-    clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
-     //  this moves the queue forward so that check_new_command() will return 1 next cycle.
-    mode = MODE_IDLE;
-    if (verbose) printf("\nGuard target lost.");
-    break;
+switch(mode) {
+	case MODE_IDLE:
+		auto_move.set_power(0); // turn off all objects in the move class
+		// now check for nearby hostile processes
+		scan_result = scan_for_threat(0, 0, TARGET_MAIN); // scan_for_threat finds the hostile process nearest to the scan centre,
+		// and saves it in the process' targetting memory.
+		// (parameters are: (x offset of scan centre from core, y offset, targetting memory address))
+		if (scan_result != 0) {
+			mode = MODE_ATTACK_FOUND; // later code means that process will attack target in targetting memory 0
+			target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
+			target_y = process[TARGET_MAIN].get_core_y();
+			target_component = 0; // attack the core
+			saved_mode = MODE_IDLE; // when leaving MODE_ATTACK_FOUND, will return to this mode
+			if (verbose)
+				printf("\nTarget found; attacking.");
+		}
+		break;
+	case MODE_MOVE_ATTACK:
+		// check for nearby hostile processes
+		scan_result = scan_for_threat(0, 0, TARGET_MAIN); // scan_for_threat finds the hostile process nearest to the scan centre,
+		// and saves it in the process' targetting memory.
+		// (parameters are: (x offset of scan centre from core, y offset, targetting memory address))
+		if (scan_result != 0) {
+			mode = MODE_ATTACK_FOUND; // later code means that process will attack target in targetting memory 0
+			target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
+			target_y = process[TARGET_MAIN].get_core_y();
+			target_component = 0; // attack the core
+			saved_mode = MODE_MOVE_ATTACK; // when leaving MODE_ATTACK_FOUND, will return to this mode
+			if (verbose)
+				printf("\nTarget found - attacking.");
+		break;
+		}
+		// fall through to MODE_MOVE case...
+	case MODE_MOVE:
+		// stop moving when within 255 pixels of target (can change to higher or lower values if needed)
+		if (distance_from_xy_less(move_x, move_y, 255)) {
+			clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
+			//  this moves the queue forward so that check_new_command() will return 1 next cycle.
+			mode = MODE_IDLE;
+			if (verbose)
+				printf("\nReached destination.");
+		} else {
+			auto_move.move_to(move_x, move_y); // calls move_to for all objects in the move class
+		}
+		break;
+	case MODE_ATTACK_FOUND:
+		// Attack target as long as it's visible.
+		// If target lost or destroyed, go back to previous action.
+		// Now see whether the commanded target is visible:
+		// (targets are visible if within scanning range of any friendly process)
+		if (!process[TARGET_MAIN].visible()) {// returns zero if not target visible or doesn't exist
+			auto_move.move_to(target_x, target_y); // calls move_to for all objects in the move class
+			if (distance_from_xy_less(target_x, target_y, 600)) {
+				// we should be able to see the target now, so it's either been destroyed
+				// or gone out of range.
+				mode = saved_mode; // the process goes back to what it was doing
+				if (verbose)
+					printf("\nTarget not detected.");
+				break;
+			}
+		} else {
+			target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
+			target_y = process[TARGET_MAIN].get_core_y();
+			auto_move.approach_target(TARGET_MAIN,target_component,700);
+			// approach_target() approaches a target to within a certain distance (700 in this case).
+			//  if the process has retro move objects it will use them to maintain the distance.
+			// Parameters are:
+			//  - target's address in targetting memory
+			//  - component of target process to attack
+			//  - stand-off distance (in pixels)
+			if (distance_from_xy_less(target_x, target_y, 1000)) {
+				auto_att_fwd.fire_at(TARGET_MAIN,target_component); // Calls fire_at() on all objects in the forward directional attack class.
+				// TARGET_MAIN indicates that the target is in targetting memory address TARGET_MAIN.
+				// target_component is the component to fire at (can be set by user's command; defaults to 0 (attack core)).
+				// fire_at() rotates directional attack objects towards the target (with basic leading) and fires.
+				front_attack_primary = 1; // this means the forward directional attack class will not try to find its own target.
+			}
+		}
+		break;
+	case MODE_ATTACK:
+		// Attack target identified by user command
+		// Now see whether the commanded target is visible:
+		// (targets are visible if within scanning range of any friendly process)
+		if (!process[TARGET_MAIN].visible()) { // returns zero if not target visible or doesn't exist
+			auto_move.move_to(target_x, target_y); // calls move_to for all objects in the move class
+			if (distance_from_xy_less(target_x, target_y, 600)) {
+				// we should be able to see the target now, so it's either been destroyed
+				// or gone out of range.
+				mode = saved_mode; // the process goes back to what it was doing
+				if (verbose)
+					printf("\nTarget not detected.");
+				break;
+			}
+		} else {
+			target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
+			target_y = process[TARGET_MAIN].get_core_y();
+			auto_move.approach_target(TARGET_MAIN,target_component,700);
+			// approach_target() approaches a target to within a certain distance (700 in this case).
+			//  if the process has retro move objects it will use them to maintain the distance.
+			// Parameters are:
+			//  - target's address in targetting memory
+			//  - component of target process to attack
+			//  - stand-off distance (in pixels)
+			if (distance_from_xy_less(target_x, target_y, 1000)) {
+				auto_att_fwd.fire_at(TARGET_MAIN,target_component); // Calls fire_at() on all objects in the forward directional attack class.
+				// TARGET_MAIN indicates that the target is in targetting memory address TARGET_MAIN.
+				// target_component is the component to fire at (can be set by user's command; defaults to 0 (attack core)).
+				// fire_at() rotates directional attack objects towards the target (with basic leading) and fires.
+				front_attack_primary = 1; // this means the forward directional attack class will not try to find its own target.
+			}
+		}
+		break;
+	case MODE_GUARD:
+		// Move in circle around friendly target identified by user command
+		//  and attack any enemies that come near
+		if (process[TARGET_GUARD].visible()) { // returns 1 if target visible. Always returns 1 for a friendly target, if it exists.
+			// check for nearby hostile processes
+			scan_result = scan_for_threat(0, 0, TARGET_MAIN); // scan_for_threat finds the hostile process nearest to the scan centre,
+			// and saves it in the process' targetting memory.
+			// (parameters are: (x offset of scan centre from core, y offset, targetting memory address))
+			if (scan_result != 0) {
+				mode = MODE_ATTACK_FOUND; // later code means that process will attack target in targetting memory 0
+				target_x = process[TARGET_MAIN].get_core_x(); // calls get_core_x() on the process in targetting memory address TARGET_MAIN
+				target_y = process[TARGET_MAIN].get_core_y();
+				target_component = 0; // attack the core
+				saved_mode = MODE_GUARD; // when leaving MODE_ATTACK_FOUND, will return to this mode
+				if (verbose)
+					printf("\nTarget found - attacking.");
+				break;
+			}
+			// Now call the circle_around_target subroutine to make this process circle the guarded process
+			circle_target = TARGET_GUARD; // circle_target is the process at the centre of the circle (here it's the process being guarded)
+			circle_rotation = 1024; // the process will aim 1024 angle units (45 degrees) around the circle, clockwise.
+			circle_distance = 700; // the process will try to stay this far from the centre of the circle
+			gosub circle_around_target; // the circle_around_target subroutine is below, near the end of the code
+			break;
+		}
+		// guard target must have been destroyed. Go back to idle mode and check for new commands.
+		clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
+		//  this moves the queue forward so that check_new_command() will return 1 next cycle.
+		mode = MODE_IDLE;
+		if (verbose)
+			printf("\nGuard target lost.");
+		break;
+}
 
-} // end of mode switch
-
-if (front_attack_primary == 0) // is 1 if the forward attack objects are attacking the main target
-{
-  auto_att_fwd.attack_scan(0, 400, TARGET_FRONT);
+if (front_attack_primary == 0) { // is 1 if the forward attack objects are attacking the main target
+	auto_att_fwd.attack_scan(0, 400, TARGET_FRONT);
 }
 
 auto_att_left.attack_scan(-2048, 400, TARGET_LEFT);
@@ -412,22 +375,20 @@ exit; // stops execution, until the next cycle
 
 // if there are any subroutines (called by gosub statements), they go here
 
-
-
 circle_around_target: // this is a label for gosub statements
-  // this subroutine makes the process circle around a target.
-  // before this subroutine was called, circle_target should have been set to
-  //  the target that the process will circle around. The target should be visible.
-  // And circle_rotation should have been set to 1024 (clockwise - for guard commands)
-  //  or -1024 (anticlockwise - for attack commands)
-  int angle_to_circle_target, circle_move_x, circle_move_y;
-  angle_to_circle_target = process[circle_target].target_angle();
-  angle_to_circle_target += circle_rotation; // this will lead the process in a circle around the target
-  circle_move_x = process[circle_target].get_core_x() // location of target
-                  + (process[circle_target].get_core_speed_x() * 10) // if the target is moving, aim for a point a little ahead of it
-                  - cos(angle_to_circle_target, circle_distance); // work out the radius of the circle around the target
-  circle_move_y = process[circle_target].get_core_y()
-                  + (process[circle_target].get_core_speed_y() * 10)
-                  - sin(angle_to_circle_target, circle_distance);
-  auto_move.move_to(circle_move_x, circle_move_y);
-  return; // returns to the statement immediately after the gosub
+	// this subroutine makes the process circle around a target.
+	// before this subroutine was called, circle_target should have been set to
+	//  the target that the process will circle around. The target should be visible.
+	// And circle_rotation should have been set to 1024 (clockwise - for guard commands)
+	//  or -1024 (anticlockwise - for attack commands)
+	int angle_to_circle_target, circle_move_x, circle_move_y;
+	angle_to_circle_target = process[circle_target].target_angle();
+	angle_to_circle_target += circle_rotation; // this will lead the process in a circle around the target
+	circle_move_x = process[circle_target].get_core_x() // location of target
+		+ (process[circle_target].get_core_speed_x() * 10) // if the target is moving, aim for a point a little ahead of it
+		- cos(angle_to_circle_target, circle_distance); // work out the radius of the circle around the target
+	circle_move_y = process[circle_target].get_core_y()
+		+ (process[circle_target].get_core_speed_y() * 10)
+		- sin(angle_to_circle_target, circle_distance);
+	auto_move.move_to(circle_move_x, circle_move_y);
+	return; // returns to the statement immediately after the gosub

--- a/bin/proc/cm_destroy.c
+++ b/bin/proc/cm_destroy.c
@@ -1,5 +1,3 @@
-
-
 #process "destroyer"
 
 // This process has objects with the following auto classes:
@@ -18,77 +16,70 @@ class auto_allocate;
 class auto_stability;
 
 core_pent_A, 0, 
-  {object_repair, 0},
-  {object_downlink, -1251, 
-    {component_cap, // component 1
-      {object_uplink, 0},
-      {object_none, 0},
-      {object_burst:auto_att_main, 1448},
-      {object_burst:auto_att_main, 433},
-    }
-  },
-  {object_downlink, 289, 
-    {component_prong, // component 2
-      {object_uplink, 0},
-      {object_move:auto_move:auto_retro, -416},
-      {object_move:auto_move, -1972},
-      {object_move:auto_move, 1770},
-    }
-  },
-  {object_downlink, -289, 
-    {component_prong, // component 3
-      {object_move:auto_move:auto_retro, 416},
-      {object_uplink, 0},
-      {object_move:auto_move, -1770},
-      {object_move:auto_move, 1972},
-    }
-  },
-  {object_downlink, 1251, 
-    {component_cap, // component 4
-      {object_burst:auto_att_main, -433},
-      {object_burst:auto_att_main, -1448},
-      {object_none, 0},
-      {object_uplink, 0},
-    }
-  },
+	{object_repair, 0},
+	{object_downlink, -1251, 
+		{component_cap, // component 1
+			{object_uplink, 0},
+			{object_none, 0},
+			{object_burst:auto_att_main, 1448},
+			{object_burst:auto_att_main, 433},
+		}
+	},
+	{object_downlink, 289, 
+		{component_prong, // component 2
+			{object_uplink, 0},
+			{object_move:auto_move:auto_retro, -416},
+			{object_move:auto_move, -1972},
+			{object_move:auto_move, 1770},
+		}
+	},
+	{object_downlink, -289, 
+		{component_prong, // component 3
+			{object_move:auto_move:auto_retro, 416},
+			{object_uplink, 0},
+			{object_move:auto_move, -1770},
+			{object_move:auto_move, 1972},
+		}
+	},
+	{object_downlink, 1251, 
+		{component_cap, // component 4
+			{object_burst:auto_att_main, -433},
+			{object_burst:auto_att_main, -1448},
+			{object_none, 0},
+			{object_uplink, 0},
+		}
+	},
 #code
 
-
-
-
 // Process AI modes (these reflect the capabilities of the process)
-enum
-{
-  MODE_IDLE, // process isn't doing anything ongoing
-  MODE_MOVE, // process is moving to target_x, target_y
-  MODE_MOVE_ATTACK, // process is moving, but will attack anything it finds along the way
-  MODE_ATTACK, // process is attacking a target it was commanded to attack
-  MODE_ATTACK_FOUND, // process is attacking a target it found itself
-  MODE_GUARD, // process is circling a friendly process
-  MODES
+enum {
+	MODE_IDLE, // process isn't doing anything ongoing
+	MODE_MOVE, // process is moving to target_x, target_y
+	MODE_MOVE_ATTACK, // process is moving, but will attack anything it finds along the way
+	MODE_ATTACK, // process is attacking a target it was commanded to attack
+	MODE_ATTACK_FOUND, // process is attacking a target it found itself
+	MODE_GUARD, // process is circling a friendly process
+	MODES
 };
 
 // Commands that the user may give the process
 // (these are fixed and should not be changed, although not all processes accept all commands)
-enum
-{
-  COM_NONE, // no command
-  COM_LOCATION, // user has right-clicked somewhere on the display or map
-  COM_TARGET, // user has right-clicked on an enemy process
-  COM_FRIEND, // user has right-clicked on a friendly process
-  COM_DATA_WELL // user has right-clicked on a data well
+enum {
+	COM_NONE, // no command
+	COM_LOCATION, // user has right-clicked somewhere on the display or map
+	COM_TARGET, // user has right-clicked on an enemy process
+	COM_FRIEND, // user has right-clicked on a friendly process
+	COM_DATA_WELL // user has right-clicked on a data well
 };
 
 // Targetting information
 // Targetting memory allows processes to track targets (enemy or friend)
 // The following enums are used as indices in the process' targetting memory
-enum
-{
-  TARGET_PARENT, // a newly built process starts with its builder in address 0
-  TARGET_MAIN, // main target
-  TARGET_GUARD, // target of guard command
+enum {
+	TARGET_PARENT, // a newly built process starts with its builder in address 0
+	TARGET_MAIN, // main target
+	TARGET_GUARD, // target of guard command
 };
-
 
 // Variable declaration and initialisation
 //  (note that declaration and initialisation cannot be combined)
@@ -118,15 +109,14 @@ int scan_result; // used to hold the results of a scan of nearby processes
 int self_destruct_primed; // counter for confirming self-destruct command (ctrl-right-click on self)
 int initialised; // set to 1 after initialisation code below run the first time
 
-if (!initialised)
-{
-   // initialisation code goes here (not all autocoded processes have initialisation code)
-  initialised = 1;
-  attack_mode(0); // attack objects (if present) will all fire together
-  // move the process forward a bit to stop it obstructing the next process to be built
-  mode = MODE_MOVE;
-  move_x = core_x + cos(angle, 300);
-  move_y = core_y + sin(angle, 300);
+if (!initialised) {
+	// initialisation code goes here (not all autocoded processes have initialisation code)
+	initialised = 1;
+	attack_mode(0); // attack objects (if present) will all fire together
+	// move the process forward a bit to stop it obstructing the next process to be built
+	mode = MODE_MOVE;
+	move_x = core_x + cos(angle, 300);
+	move_y = core_y + sin(angle, 300);
 }
 
 int verbose; // if 1, process will print various things to the console

--- a/bin/proc/cm_harvest.c
+++ b/bin/proc/cm_harvest.c
@@ -1,5 +1,3 @@
-
-
 #process "harvester"
 
 // This process has objects with the following auto classes:
@@ -18,57 +16,50 @@ class auto_allocate;
 class auto_stability;
 
 core_quad_A, 4096, 
-  {object_harvest:auto_harvest, 0},
-  {object_move:auto_move, -2048},
-  {object_storage, 0},
-  {object_move:auto_move, 2048},
+	{object_harvest:auto_harvest, 0},
+	{object_move:auto_move, -2048},
+	{object_storage, 0},
+	{object_move:auto_move, 2048},
 #code
 
-
-
-
 // Process AI modes (these reflect the capabilities of the process)
-enum
-{
-  MODE_IDLE, // process isn't doing anything ongoing
-  MODE_MOVE, // process is moving to target_x, target_y
-  MODE_HARVEST, // process is harvesting data from a data well (or travelling to do so)
-  MODE_HARVEST_RETURN, // process has harvested data and is returning to an allocator
-  MODE_GUARD, // process is circling a friendly process
-  MODES
+enum {
+	MODE_IDLE, // process isn't doing anything ongoing
+	MODE_MOVE, // process is moving to target_x, target_y
+	MODE_HARVEST, // process is harvesting data from a data well (or travelling to do so)
+	MODE_HARVEST_RETURN, // process has harvested data and is returning to an allocator
+	MODE_GUARD, // process is circling a friendly process
+	MODES
 };
 
 // Commands that the user may give the process
 // (these are fixed and should not be changed, although not all processes accept all commands)
-enum
-{
-  COM_NONE, // no command
-  COM_LOCATION, // user has right-clicked somewhere on the display or map
-  COM_TARGET, // user has right-clicked on an enemy process
-  COM_FRIEND, // user has right-clicked on a friendly process
-  COM_DATA_WELL // user has right-clicked on a data well
+enum {
+	COM_NONE, // no command
+	COM_LOCATION, // user has right-clicked somewhere on the display or map
+	COM_TARGET, // user has right-clicked on an enemy process
+	COM_FRIEND, // user has right-clicked on a friendly process
+	COM_DATA_WELL // user has right-clicked on a data well
 };
 
 // Targetting information
 // Targetting memory allows processes to track targets (enemy or friend)
 // The following enums are used as indices in the process' targetting memory
-enum
-{
-  TARGET_PARENT, // a newly built process starts with its builder in address 0
-  TARGET_ALLOCATOR, // process that this process will return to when finished harvesting
-  TARGET_GUARD, // target of guard command
+enum {
+	TARGET_PARENT, // a newly built process starts with its builder in address 0
+	TARGET_ALLOCATOR, // process that this process will return to when finished harvesting
+	TARGET_GUARD, // target of guard command
 };
 
-
 // Variable declaration and initialisation
-//  (note that declaration and initialisation cannot be combined)
-//  (also, variables retain their values between execution cycles)
+// (note that declaration and initialisation cannot be combined)
+// (also, variables retain their values between execution cycles)
 int core_x, core_y; // location of core
 core_x = get_core_x(); // location is updated each cycle
 core_y = get_core_y();
 int angle; // direction process is pointing
- // angles are in integer degrees from 0 to 8192, with 0 being right,
- // 2048 down, 4096 left and 6144 (or -2048) up.
+// angles are in integer degrees from 0 to 8192, with 0 being right,
+// 2048 down, 4096 left and 6144 (or -2048) up.
 angle = get_core_angle(); // angle is updated each cycle
 
 int mode; // what is the process doing? (should be one of the MODE enums)
@@ -80,7 +71,7 @@ int circle_rotation; // direction to circle the target in (should be 1024 for cl
 int circle_distance; // distance to maintain from the centre of the circle
 
 int target_component; // target component for an attack command (allows user to
- // target specific components)
+// target specific components)
 
 int scan_result; // used to hold the results of a scan of nearby processes
 
@@ -91,205 +82,185 @@ int data_well_x, data_well_y; // location of data well
 int allocator_x, allocator_y; // location of process this process will return to with data
 int initialised; // set to 1 after initialisation code below run the first time
 
-if (!initialised)
-{
-   // initialisation code goes here (not all autocoded processes have initialisation code)
-  initialised = 1;
-  attack_mode(0); // attack objects (if present) will all fire together
-  // move the process forward a bit to stop it obstructing the next process to be built
-  mode = MODE_MOVE;
-  move_x = core_x + cos(angle, 300);
-  move_y = core_y + sin(angle, 300);
-  // Harvester assumes that it was built by an allocator,
-  //  and will return to its parent when full of harvested data.
-  target_copy(TARGET_ALLOCATOR, TARGET_PARENT); // copies parent to TARGET_ALLOCATOR
-  allocator_x = process[TARGET_ALLOCATOR].get_core_x();
-  allocator_y = process[TARGET_ALLOCATOR].get_core_y();
+if (!initialised) {
+	// initialisation code goes here (not all autocoded processes have initialisation code)
+	initialised = 1;
+	attack_mode(0); // attack objects (if present) will all fire together
+	// move the process forward a bit to stop it obstructing the next process to be built
+	mode = MODE_MOVE;
+	move_x = core_x + cos(angle, 300);
+	move_y = core_y + sin(angle, 300);
+	// Harvester assumes that it was built by an allocator,
+	// and will return to its parent when full of harvested data.
+	target_copy(TARGET_ALLOCATOR, TARGET_PARENT); // copies parent to TARGET_ALLOCATOR
+	allocator_x = process[TARGET_ALLOCATOR].get_core_x();
+	allocator_y = process[TARGET_ALLOCATOR].get_core_y();
 }
 
 int verbose; // if 1, process will print various things to the console
 
-if (check_selected_single()) // returns 1 if the user has selected this process (and no other processes)
-{
-  if (!verbose) printf("\nProcess selected.");
-  verbose = 1;
-  set_debug_mode(1); // 1 means errors for this process will be printed to the console. Resets to 0 each cycle
+if (check_selected_single()) { // returns 1 if the user has selected this process (and no other processes)
+	if (!verbose)
+		printf("\nProcess selected.");
+	verbose = 1;
+	set_debug_mode(1); // 1 means errors for this process will be printed to the console. Resets to 0 each cycle
+} else {
+	verbose = 0;
 }
-  else
-    verbose = 0;
-
 
 // Accept commands from user
-if (check_new_command() == 1) // returns 1 if a command has been given
-{
-  switch(get_command_type()) // get_command_type() returns the type of command given
-  {
-    case COM_LOCATION:
-      move_x = get_command_x(); // get_command_x() and ...y() return the target location of the command
-      move_y = get_command_y();
-      mode = MODE_MOVE;
-      if (verbose) printf("\nMoving.");
-      break;
-    
-    case COM_TARGET:
-      if (verbose) printf("\nTarget command not recognised.");
-      break;
-    
-    case COM_DATA_WELL:
-      data_well_x = get_command_x();
-      data_well_y = get_command_y();
-       // (targetting memory stores the target and allows the process to examine it if it's in scanning range)
-      if (mode != MODE_HARVEST_RETURN) // can reassign target data well while process returning with harvest without changing mode
-        mode = MODE_HARVEST;
-      if (verbose) printf("\nHarvesting from data well.");
-      break;
-    
-    case COM_FRIEND:
-      allocator_x = get_command_x();
-      allocator_y = get_command_y();
-      get_command_target(TARGET_ALLOCATOR); // writes the target of the command to address TARGET_ALLOCATOR in targetting memory
-      if (get_command_ctrl() && process[TARGET_ALLOCATOR].get_core_x() == get_core_x() && process[TARGET_ALLOCATOR].get_core_y() == get_core_y())
-      {
-        if (self_destruct_primed > 0)
-        {
-          printf("\nTerminating.");
-          terminate; // this causes the process to self-destruct
-        }
-        printf("\nSelf destruct primed.");
-        printf("\nRepeat command (ctrl-right-click self) to confirm.");
-        self_destruct_primed = 20;
-        break;
-      }
-      if (mode != MODE_HARVEST)
-        mode = MODE_HARVEST_RETURN;
-      if (verbose) printf("\nHarvester return set.");
-      break;
-    
-    default:
-      if (verbose) printf("\nUnrecognised command.");
-      break;
-  
-  } // end of command type switch
-} // end of new command code
+if (check_new_command() == 1) { // returns 1 if a command has been given
+	switch(get_command_type()) { // get_command_type() returns the type of command given
+	case COM_LOCATION:
+		move_x = get_command_x(); // get_command_x() and ...y() return the target location of the command
+		move_y = get_command_y();
+		mode = MODE_MOVE;
+		if (verbose)
+			printf("\nMoving.");
+		break;
+	case COM_TARGET:
+		if (verbose)
+			printf("\nTarget command not recognised.");
+		break;
+	case COM_DATA_WELL:
+		data_well_x = get_command_x();
+		data_well_y = get_command_y();
+		// (targetting memory stores the target and allows the process to examine it if it's in scanning range)
+		if (mode != MODE_HARVEST_RETURN) // can reassign target data well while process returning with harvest without changing mode
+			mode = MODE_HARVEST;
 
+		if (verbose)
+			printf("\nHarvesting from data well.");
+		break;
+	case COM_FRIEND:
+		allocator_x = get_command_x();
+		allocator_y = get_command_y();
+		get_command_target(TARGET_ALLOCATOR); // writes the target of the command to address TARGET_ALLOCATOR in targetting memory
+		if (get_command_ctrl() &&
+			process[TARGET_ALLOCATOR].get_core_x() == get_core_x() &&
+			process[TARGET_ALLOCATOR].get_core_y() == get_core_y()) {
+			if (self_destruct_primed > 0) {
+				printf("\nTerminating.");
+				terminate; // this causes the process to self-destruct
+			}
+			printf("\nSelf destruct primed.");
+			printf("\nRepeat command (ctrl-right-click self) to confirm.");
+			self_destruct_primed = 20;
+			break;
+		}
+		if (mode != MODE_HARVEST)
+			mode = MODE_HARVEST_RETURN;
 
-if (self_destruct_primed > 0)
-{
-  self_destruct_primed --;
-  if (self_destruct_primed == 0
-   && verbose)
-    printf("\nSelf destruct cancelled.");
+		if (verbose)
+			printf("\nHarvester return set.");
+		break;
+	default:
+		if (verbose)
+			printf("\nUnrecognised command.");
+		break;
+	}
 }
 
+if (self_destruct_primed > 0) {
+	self_destruct_primed --;
+	if (self_destruct_primed == 0 && verbose)
+		printf("\nSelf destruct cancelled.");
+}
 
 // What the process does next depends on its current mode
-switch(mode)
-{
-  
-  case MODE_IDLE:
-    auto_move.set_power(0); // turn off all objects in the move class
-    break;
-  
-  case MODE_MOVE:
-  // stop moving when within 255 pixels of target (can change to higher or lower values if needed)
-    if (distance_from_xy_less(move_x, move_y, 255))
-    {
-      clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
-       //  this moves the queue forward so that check_new_command() will return 1 next cycle.
-      // Now, a command to move somewhere near a data well was probably meant as a harvest command:
-      if (get_data_stored() < get_data_capacity()
-       && search_for_well())
-      {
-        mode = MODE_HARVEST;
-        data_well_x = get_well_x();
-        data_well_y = get_well_y();
-        if (verbose) printf("\nHarvesting.");
-      }
-        else
-        {
-          mode = MODE_IDLE;
-          if (verbose) printf("\nReached destination.");
-        }
-    }
-      else
-        auto_move.move_to(move_x, move_y); // calls move_to for all objects in the move class
-    break;
-  
-  case MODE_HARVEST:
-    if (abs(core_x - data_well_x) < 1000 && abs(core_y - data_well_y) < 1000)
-      auto_harvest.gather_data(); // only gather if near target (avoids inadvertently gathering from another well)
-    auto_move.move_to(data_well_x, data_well_y);
-    if (get_data_stored() == get_data_capacity() || get_damage() > 0)
-    {
-      mode = MODE_HARVEST_RETURN;
-      if (verbose) printf("\nReturning to allocator.");
-    }
-    break;
-  
-  case MODE_HARVEST_RETURN:
-    auto_harvest.give_data(TARGET_ALLOCATOR, 100);
-    auto_move.move_to(allocator_x, allocator_y);
-    if (get_data_stored() == 0
-     && get_data_capacity() > 0) // if 0, probably means the harvester is damaged.
-    {
-      if (data_well_x != 0)
-      {
-        // if the harvester has a data well to harvest from, go back to harvest mode:
-        mode = MODE_HARVEST;
-        if (verbose) printf("\nHarvesting.");
-      }
-        else
-          {
-            // if data_well_x is 0, the harvester has probably just been built and sent a command to
-            // guard its parent (which it may have interpreted as a command to set its harvest return target).
-            // if so, it should just go into guard mode:
-            mode = MODE_GUARD;
-            target_copy(TARGET_GUARD, TARGET_ALLOCATOR); // copy from TARGET_ALLOCATOR to TARGET_GUARD
-            if (verbose) printf("\nGuarding.");
-          }
-      }
-    break;
-  
-  case MODE_GUARD:
-  // Move in circle around friendly target identified by user command
-    if (process[TARGET_GUARD].visible()) // returns 1 if target visible. Always returns 1 for a friendly target, if it exists.
-    {
-      // Now call the circle_around_target subroutine to make this process circle the guarded process
-      circle_target = TARGET_GUARD; // circle_target is the process at the centre of the circle (here it's the process being guarded)
-      circle_rotation = 1024; // the process will aim 1024 angle units (45 degrees) around the circle, clockwise.
-      circle_distance = 700; // the process will try to stay this far from the centre of the circle
-      gosub circle_around_target; // the circle_around_target subroutine is below, near the end of the code
-      break;
-    }
-    // guard target must have been destroyed. Go back to idle mode and check for new commands.
-    clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
-     //  this moves the queue forward so that check_new_command() will return 1 next cycle.
-    mode = MODE_IDLE;
-    if (verbose) printf("\nGuard target lost.");
-    break;
+switch(mode) {
+	case MODE_IDLE:
+		auto_move.set_power(0); // turn off all objects in the move class
+		break;
+	case MODE_MOVE:
+		// stop moving when within 255 pixels of target (can change to higher or lower values if needed)
+		if (distance_from_xy_less(move_x, move_y, 255)) {
+			clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
+			//  this moves the queue forward so that check_new_command() will return 1 next cycle.
+			// Now, a command to move somewhere near a data well was probably meant as a harvest command:
+			if (get_data_stored() < get_data_capacity() && search_for_well()) {
+				mode = MODE_HARVEST;
+				data_well_x = get_well_x();
+				data_well_y = get_well_y();
+				if (verbose)
+					printf("\nHarvesting.");
+			} else {
+				mode = MODE_IDLE;
+				if (verbose)
+					printf("\nReached destination.");
+			}
+		} else {
+			auto_move.move_to(move_x, move_y); // calls move_to for all objects in the move class
+		}
+		break;
+	case MODE_HARVEST:
+		if (abs(core_x - data_well_x) < 1000 && abs(core_y - data_well_y) < 1000)
+			auto_harvest.gather_data(); // only gather if near target (avoids inadvertently gathering from another well)
 
-} // end of mode switch
+		auto_move.move_to(data_well_x, data_well_y);
+		if (get_data_stored() == get_data_capacity() || get_damage() > 0) {
+			mode = MODE_HARVEST_RETURN;
+			if (verbose)
+				printf("\nReturning to allocator.");
+		}
+		break;
+	case MODE_HARVEST_RETURN:
+		auto_harvest.give_data(TARGET_ALLOCATOR, 100);
+		auto_move.move_to(allocator_x, allocator_y);
+		if (get_data_stored() == 0 && get_data_capacity() > 0) { // if 0, probably means the harvester is damaged.
+			if (data_well_x != 0) {
+			// if the harvester has a data well to harvest from, go back to harvest mode:
+				mode = MODE_HARVEST;
+				if (verbose)
+					printf("\nHarvesting.");
+			} else {
+				// if data_well_x is 0, the harvester has probably just been built and sent a command to
+				// guard its parent (which it may have interpreted as a command to set its harvest return target).
+				// if so, it should just go into guard mode:
+				mode = MODE_GUARD;
+				target_copy(TARGET_GUARD, TARGET_ALLOCATOR); // copy from TARGET_ALLOCATOR to TARGET_GUARD
+				if (verbose)
+					printf("\nGuarding.");
+			}
+		}
+		break;
+	case MODE_GUARD:
+		// Move in circle around friendly target identified by user command
+		if (process[TARGET_GUARD].visible()) { // returns 1 if target visible. Always returns 1 for a friendly target, if it exists.
+			// Now call the circle_around_target subroutine to make this process circle the guarded process
+			circle_target = TARGET_GUARD; // circle_target is the process at the centre of the circle (here it's the process being guarded)
+			circle_rotation = 1024; // the process will aim 1024 angle units (45 degrees) around the circle, clockwise.
+			circle_distance = 700; // the process will try to stay this far from the centre of the circle
+			gosub circle_around_target; // the circle_around_target subroutine is below, near the end of the code
+			break;
+		}
+		// guard target must have been destroyed. Go back to idle mode and check for new commands.
+		clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
+		//  this moves the queue forward so that check_new_command() will return 1 next cycle.
+		mode = MODE_IDLE;
+		if (verbose)
+			printf("\nGuard target lost.");
+		break;
+}
 
 exit; // stops execution, until the next cycle
 
 // if there are any subroutines (called by gosub statements), they go here
 
-
-
 circle_around_target: // this is a label for gosub statements
-  // this subroutine makes the process circle around a target.
-  // before this subroutine was called, circle_target should have been set to
-  //  the target that the process will circle around. The target should be visible.
-  // And circle_rotation should have been set to 1024 (clockwise - for guard commands)
-  //  or -1024 (anticlockwise - for attack commands)
-  int angle_to_circle_target, circle_move_x, circle_move_y;
-  angle_to_circle_target = process[circle_target].target_angle();
-  angle_to_circle_target += circle_rotation; // this will lead the process in a circle around the target
-  circle_move_x = process[circle_target].get_core_x() // location of target
-                  + (process[circle_target].get_core_speed_x() * 10) // if the target is moving, aim for a point a little ahead of it
-                  - cos(angle_to_circle_target, circle_distance); // work out the radius of the circle around the target
-  circle_move_y = process[circle_target].get_core_y()
-                  + (process[circle_target].get_core_speed_y() * 10)
-                  - sin(angle_to_circle_target, circle_distance);
-  auto_move.move_to(circle_move_x, circle_move_y);
-  return; // returns to the statement immediately after the gosub
+	// this subroutine makes the process circle around a target.
+	// before this subroutine was called, circle_target should have been set to
+	//  the target that the process will circle around. The target should be visible.
+	// And circle_rotation should have been set to 1024 (clockwise - for guard commands)
+	//  or -1024 (anticlockwise - for attack commands)
+	int angle_to_circle_target, circle_move_x, circle_move_y;
+	angle_to_circle_target = process[circle_target].target_angle();
+	angle_to_circle_target += circle_rotation; // this will lead the process in a circle around the target
+	circle_move_x = process[circle_target].get_core_x() // location of target
+		+ (process[circle_target].get_core_speed_x() * 10) // if the target is moving, aim for a point a little ahead of it
+		- cos(angle_to_circle_target, circle_distance); // work out the radius of the circle around the target
+	circle_move_y = process[circle_target].get_core_y()
+		+ (process[circle_target].get_core_speed_y() * 10)
+		- sin(angle_to_circle_target, circle_distance);
+	auto_move.move_to(circle_move_x, circle_move_y);
+	return; // returns to the statement immediately after the gosub

--- a/bin/proc/cm_mbuild.c
+++ b/bin/proc/cm_mbuild.c
@@ -1,5 +1,3 @@
-
-
 #process "mbuild"
 
 // This process has objects with the following auto classes:
@@ -18,68 +16,61 @@ class auto_allocate;
 class auto_stability;
 
 core_quad_B, 0, 
-  {object_build, 0},
-  {object_repair, 0},
-  {object_downlink, 147, 
-    {component_fork, // component 1
-      {object_move:auto_move, 2048},
-      {object_uplink, 0},
-      {object_move:auto_move, -986},
-    }
-  },
-  {object_downlink, -147, 
-    {component_fork, // component 2
-      {object_move:auto_move, -2048},
-      {object_move:auto_move, 986},
-      {object_uplink, 0},
-    }
-  },
+	{object_build, 0},
+	{object_repair, 0},
+	{object_downlink, 147, 
+		{component_fork, // component 1
+			{object_move:auto_move, 2048},
+			{object_uplink, 0},
+			{object_move:auto_move, -986},
+		}
+	},
+	{object_downlink, -147, 
+		{component_fork, // component 2
+			{object_move:auto_move, -2048},
+			{object_move:auto_move, 986},
+			{object_uplink, 0},
+		}
+	},
 #code
 
-
-
-
 // Process AI modes (these reflect the capabilities of the process)
-enum
-{
-  MODE_IDLE, // process isn't doing anything ongoing
-  MODE_MOVE, // process is moving to target_x, target_y
-  MODE_MOVE_BUILD, // process is moving somewhere to build a process there
-  MODE_GUARD, // process is circling a friendly process
-  MODES
+enum {
+	MODE_IDLE, // process isn't doing anything ongoing
+	MODE_MOVE, // process is moving to target_x, target_y
+	MODE_MOVE_BUILD, // process is moving somewhere to build a process there
+	MODE_GUARD, // process is circling a friendly process
+	MODES
 };
 
 // Commands that the user may give the process
 // (these are fixed and should not be changed, although not all processes accept all commands)
-enum
-{
-  COM_NONE, // no command
-  COM_LOCATION, // user has right-clicked somewhere on the display or map
-  COM_TARGET, // user has right-clicked on an enemy process
-  COM_FRIEND, // user has right-clicked on a friendly process
-  COM_DATA_WELL // user has right-clicked on a data well
+enum {
+	COM_NONE, // no command
+	COM_LOCATION, // user has right-clicked somewhere on the display or map
+	COM_TARGET, // user has right-clicked on an enemy process
+	COM_FRIEND, // user has right-clicked on a friendly process
+	COM_DATA_WELL // user has right-clicked on a data well
 };
 
 // Targetting information
 // Targetting memory allows processes to track targets (enemy or friend)
 // The following enums are used as indices in the process' targetting memory
-enum
-{
-  TARGET_PARENT, // a newly built process starts with its builder in address 0
-  TARGET_BUILT, // processes built by this process
-  TARGET_GUARD, // target of guard command
+enum {
+	TARGET_PARENT, // a newly built process starts with its builder in address 0
+	TARGET_BUILT, // processes built by this process
+	TARGET_GUARD, // target of guard command
 };
 
-
 // Variable declaration and initialisation
-//  (note that declaration and initialisation cannot be combined)
-//  (also, variables retain their values between execution cycles)
+// (note that declaration and initialisation cannot be combined)
+// (also, variables retain their values between execution cycles)
 int core_x, core_y; // location of core
 core_x = get_core_x(); // location is updated each cycle
 core_y = get_core_y();
 int angle; // direction process is pointing
- // angles are in integer degrees from 0 to 8192, with 0 being right,
- // 2048 down, 4096 left and 6144 (or -2048) up.
+// angles are in integer degrees from 0 to 8192, with 0 being right,
+// 2048 down, 4096 left and 6144 (or -2048) up.
 angle = get_core_angle(); // angle is updated each cycle
 
 int mode; // what is the process doing? (should be one of the MODE enums)
@@ -91,7 +82,7 @@ int circle_rotation; // direction to circle the target in (should be 1024 for cl
 int circle_distance; // distance to maintain from the centre of the circle
 
 int target_component; // target component for an attack command (allows user to
- // target specific components)
+// target specific components)
 
 int scan_result; // used to hold the results of a scan of nearby processes
 
@@ -103,141 +94,126 @@ int build_x, build_y; // build location for move-build commands
 int build_target_angle; // used in calculating target for commands that result in MODE_MOVE_BUILD
 int initialised; // set to 1 after initialisation code below run the first time
 
-if (!initialised)
-{
-   // initialisation code goes here (not all autocoded processes have initialisation code)
-  initialised = 1;
-  attack_mode(0); // attack objects (if present) will all fire together
-  // move the process forward a bit to stop it obstructing the next process to be built
-  mode = MODE_MOVE;
-  move_x = core_x + cos(angle, 300);
-  move_y = core_y + sin(angle, 300);
+if (!initialised) {
+	// initialisation code goes here (not all autocoded processes have initialisation code)
+	initialised = 1;
+	attack_mode(0); // attack objects (if present) will all fire together
+	// move the process forward a bit to stop it obstructing the next process to be built
+	mode = MODE_MOVE;
+	move_x = core_x + cos(angle, 300);
+	move_y = core_y + sin(angle, 300);
 }
 
 int verbose; // if 1, process will print various things to the console
 
-if (check_selected_single()) // returns 1 if the user has selected this process (and no other processes)
-{
-  if (!verbose) printf("\nProcess selected.");
-  verbose = 1;
-  set_debug_mode(1); // 1 means errors for this process will be printed to the console. Resets to 0 each cycle
+if (check_selected_single()) { // returns 1 if the user has selected this process (and no other processes)
+	if (!verbose)
+		printf("\nProcess selected.");
+	verbose = 1;
+	set_debug_mode(1); // 1 means errors for this process will be printed to the console. Resets to 0 each cycle
+} else {
+	verbose = 0;
 }
-  else
-    verbose = 0;
-
 
 // Accept commands from user
-if (check_new_command() == 1) // returns 1 if a command has been given
-{
-  switch(get_command_type()) // get_command_type() returns the type of command given
-  {
-    case COM_LOCATION:
-    case COM_DATA_WELL: // this process can't harvest, so treat data well commands as location commands
-      move_x = get_command_x(); // get_command_x() and ...y() return the target location of the command
-      move_y = get_command_y();
-      mode = MODE_MOVE;
-      if (verbose) printf("\nMoving.");
-      break;
-    
-    case COM_TARGET:
-      if (verbose) printf("\nTarget command not recognised.");
-      break;
-    
-    case COM_FRIEND:
-      get_command_target(TARGET_GUARD); // writes the target of the command to address TARGET_GUARD in targetting memory
-       // (targetting memory stores the target and allows the process to examine it if it's in scanning range)
-      if (get_command_ctrl() && process[TARGET_GUARD].get_core_x() == get_core_x() && process[TARGET_GUARD].get_core_y() == get_core_y())
-      {
-        if (self_destruct_primed > 0)
-        {
-          printf("\nTerminating.");
-          terminate; // this causes the process to self-destruct
-        }
-        printf("\nSelf destruct primed.");
-        printf("\nRepeat command (ctrl-right-click self) to confirm.");
-        self_destruct_primed = 20;
-        break;
-      }
-      mode = MODE_GUARD;
-      if (verbose) printf("\nGuarding.");
-      break;
-    
-    default:
-      if (verbose) printf("\nUnrecognised command.");
-      break;
-  
-  } // end of command type switch
-} // end of new command code
-
-
-if (self_destruct_primed > 0)
-{
-  self_destruct_primed --;
-  if (self_destruct_primed == 0
-   && verbose)
-    printf("\nSelf destruct cancelled.");
+if (check_new_command() == 1) { // returns 1 if a command has been given
+	switch(get_command_type()) { // get_command_type() returns the type of command given
+	case COM_LOCATION:
+	case COM_DATA_WELL: // this process can't harvest, so treat data well commands as location commands
+		move_x = get_command_x(); // get_command_x() and ...y() return the target location of the command
+		move_y = get_command_y();
+		mode = MODE_MOVE;
+		if (verbose)
+			printf("\nMoving.");
+		break;
+	case COM_TARGET:
+		if (verbose)
+			printf("\nTarget command not recognised.");
+		break;
+	case COM_FRIEND:
+		get_command_target(TARGET_GUARD); // writes the target of the command to address TARGET_GUARD in targetting memory
+		// (targetting memory stores the target and allows the process to examine it if it's in scanning range)
+		if (get_command_ctrl() &&
+			process[TARGET_GUARD].get_core_x() == get_core_x() &&
+			process[TARGET_GUARD].get_core_y() == get_core_y()) {
+			if (self_destruct_primed > 0) {
+				printf("\nTerminating.");
+				terminate; // this causes the process to self-destruct
+			}
+			printf("\nSelf destruct primed.");
+			printf("\nRepeat command (ctrl-right-click self) to confirm.");
+			self_destruct_primed = 20;
+			break;
+		}
+		mode = MODE_GUARD;
+		if (verbose)
+			printf("\nGuarding.");
+		break;
+	default:
+		if (verbose)
+			printf("\nUnrecognised command.");
+		break;
+	}
 }
 
+if (self_destruct_primed > 0) {
+	self_destruct_primed --;
+	if (self_destruct_primed == 0 && verbose)
+		printf("\nSelf destruct cancelled.");
+}
 
 // What the process does next depends on its current mode
-switch(mode)
-{
-  
-  case MODE_IDLE:
-    auto_move.set_power(0); // turn off all objects in the move class
-    gosub check_for_build_command; // this jumps to the check_for_build_command subroutine, then jumps back on return.
-    // (subroutines are at the end of the source code, below)
-    break;
-  
-  case MODE_MOVE:
-  // stop moving when within 255 pixels of target (can change to higher or lower values if needed)
-    if (distance_from_xy_less(move_x, move_y, 255))
-    {
-      clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
-       //  this moves the queue forward so that check_new_command() will return 1 next cycle.
-      mode = MODE_IDLE;
-      if (verbose) printf("\nReached destination.");
-    }
-      else
-        auto_move.move_to(move_x, move_y); // calls move_to for all objects in the move class
-    break;
-  
-  case MODE_MOVE_BUILD:
-  // stop moving when within 80 pixels of target (can change to higher or lower values if needed)
-    if (distance_from_xy_less(build_x, build_y, 800)) // build range is about 1000
-    {
-      // now try to build (build_from_queue() will just fail if this process' build command isn't at the front of the queue)
-      if (build_from_queue(TARGET_BUILT) == 1) // build_from_queue() returns 1 on success
-      {
-        mode = MODE_IDLE;
-        if (verbose) printf("\nProcess built.");
-      }
-    }
-      else
-        auto_move.move_to(move_x, move_y); // calls move_to for all objects in the move class
-    break;
-  
-  case MODE_GUARD:
-  // Move in circle around friendly target identified by user command
-    if (process[TARGET_GUARD].visible()) // returns 1 if target visible. Always returns 1 for a friendly target, if it exists.
-    {
-      // Now call the circle_around_target subroutine to make this process circle the guarded process
-      circle_target = TARGET_GUARD; // circle_target is the process at the centre of the circle (here it's the process being guarded)
-      circle_rotation = 1024; // the process will aim 1024 angle units (45 degrees) around the circle, clockwise.
-      circle_distance = 700; // the process will try to stay this far from the centre of the circle
-      gosub circle_around_target; // the circle_around_target subroutine is below, near the end of the code
-      gosub check_for_build_command; // this jumps to the check_for_build_command subroutine, then jumps back on return.
-      // (subroutines are at the end of the source code, below)
-      break;
-    }
-    // guard target must have been destroyed. Go back to idle mode and check for new commands.
-    clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
-     //  this moves the queue forward so that check_new_command() will return 1 next cycle.
-    mode = MODE_IDLE;
-    if (verbose) printf("\nGuard target lost.");
-    break;
-
-} // end of mode switch
+switch(mode) {
+	case MODE_IDLE:
+		auto_move.set_power(0); // turn off all objects in the move class
+		gosub check_for_build_command; // this jumps to the check_for_build_command subroutine, then jumps back on return.
+		// (subroutines are at the end of the source code, below)
+		break;
+	case MODE_MOVE:
+		// stop moving when within 255 pixels of target (can change to higher or lower values if needed)
+		if (distance_from_xy_less(move_x, move_y, 255)) {
+			clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
+			//  this moves the queue forward so that check_new_command() will return 1 next cycle.
+			mode = MODE_IDLE;
+			if (verbose)
+				printf("\nReached destination.");
+		} else {
+			auto_move.move_to(move_x, move_y); // calls move_to for all objects in the move class
+		}
+		break;
+	case MODE_MOVE_BUILD:
+		// stop moving when within 80 pixels of target (can change to higher or lower values if needed)
+		if (distance_from_xy_less(build_x, build_y, 800)) { // build range is about 1000
+			// now try to build (build_from_queue() will just fail if this process' build command isn't at the front of the queue)
+			if (build_from_queue(TARGET_BUILT) == 1) { // build_from_queue() returns 1 on success
+				mode = MODE_IDLE;
+				if (verbose)
+					printf("\nProcess built.");
+			}
+		} else {
+			auto_move.move_to(move_x, move_y); // calls move_to for all objects in the move class
+		}
+		break;
+	case MODE_GUARD:
+		// Move in circle around friendly target identified by user command
+		if (process[TARGET_GUARD].visible()) { // returns 1 if target visible. Always returns 1 for a friendly target, if it exists.
+			// Now call the circle_around_target subroutine to make this process circle the guarded process
+			circle_target = TARGET_GUARD; // circle_target is the process at the centre of the circle (here it's the process being guarded)
+			circle_rotation = 1024; // the process will aim 1024 angle units (45 degrees) around the circle, clockwise.
+			circle_distance = 700; // the process will try to stay this far from the centre of the circle
+			gosub circle_around_target; // the circle_around_target subroutine is below, near the end of the code
+			gosub check_for_build_command; // this jumps to the check_for_build_command subroutine, then jumps back on return.
+			// (subroutines are at the end of the source code, below)
+			break;
+		}
+		// guard target must have been destroyed. Go back to idle mode and check for new commands.
+		clear_command(); // cancels the current command. If there's a queue of commands (e.g. shift-move waypoints)
+		//  this moves the queue forward so that check_new_command() will return 1 next cycle.
+		mode = MODE_IDLE;
+		if (verbose)
+			printf("\nGuard target lost.");
+		break;
+}
 
 restore_self(); // tries to restore any destroyed components
 
@@ -247,38 +223,35 @@ exit; // stops execution, until the next cycle
 
 // if there are any subroutines (called by gosub statements), they go here
 
-
-
 check_for_build_command: // this is a label for gosub statements
-  // let's see if there is a build command on the queue for this process
-  if (check_build_queue() > 0) // returns the number of build commands on the queue for this process
-  {
-    build_x = build_queue_get_x(); // returns absolute location of the first queued command for this process
-    build_y = build_queue_get_y(); //  - note that the command may not be at the front of the whole queue
-    mode = MODE_MOVE_BUILD;
-    // let's move to somewhere near the build location, but not right on it (or this process might get in the way)
-    build_target_angle = atan2(build_y - core_y, build_x - core_x);
-    move_x = build_x - cos(build_target_angle, 300); // stop short of target
-    move_y = build_y - sin(build_target_angle, 300);
-    if (verbose) printf("\nMoving to build location.");
-  } // end if (check_build_queue() > 0)
-  return; // returns to the statement immediately after the gosub
-
+// let's see if there is a build command on the queue for this process
+	if (check_build_queue() > 0) { // returns the number of build commands on the queue for this process
+		build_x = build_queue_get_x(); // returns absolute location of the first queued command for this process
+		build_y = build_queue_get_y(); //  - note that the command may not be at the front of the whole queue
+		mode = MODE_MOVE_BUILD;
+		// let's move to somewhere near the build location, but not right on it (or this process might get in the way)
+		build_target_angle = atan2(build_y - core_y, build_x - core_x);
+		move_x = build_x - cos(build_target_angle, 300); // stop short of target
+		move_y = build_y - sin(build_target_angle, 300);
+		if (verbose)
+			printf("\nMoving to build location.");
+	} // end if (check_build_queue() > 0)
+	return; // returns to the statement immediately after the gosub
 
 circle_around_target: // this is a label for gosub statements
-  // this subroutine makes the process circle around a target.
-  // before this subroutine was called, circle_target should have been set to
-  //  the target that the process will circle around. The target should be visible.
-  // And circle_rotation should have been set to 1024 (clockwise - for guard commands)
-  //  or -1024 (anticlockwise - for attack commands)
-  int angle_to_circle_target, circle_move_x, circle_move_y;
-  angle_to_circle_target = process[circle_target].target_angle();
-  angle_to_circle_target += circle_rotation; // this will lead the process in a circle around the target
-  circle_move_x = process[circle_target].get_core_x() // location of target
-                  + (process[circle_target].get_core_speed_x() * 10) // if the target is moving, aim for a point a little ahead of it
-                  - cos(angle_to_circle_target, circle_distance); // work out the radius of the circle around the target
-  circle_move_y = process[circle_target].get_core_y()
-                  + (process[circle_target].get_core_speed_y() * 10)
-                  - sin(angle_to_circle_target, circle_distance);
-  auto_move.move_to(circle_move_x, circle_move_y);
-  return; // returns to the statement immediately after the gosub
+	// this subroutine makes the process circle around a target.
+	// before this subroutine was called, circle_target should have been set to
+	//  the target that the process will circle around. The target should be visible.
+	// And circle_rotation should have been set to 1024 (clockwise - for guard commands)
+	//  or -1024 (anticlockwise - for attack commands)
+	int angle_to_circle_target, circle_move_x, circle_move_y;
+	angle_to_circle_target = process[circle_target].target_angle();
+	angle_to_circle_target += circle_rotation; // this will lead the process in a circle around the target
+	circle_move_x = process[circle_target].get_core_x() // location of target
+		+ (process[circle_target].get_core_speed_x() * 10) // if the target is moving, aim for a point a little ahead of it
+		- cos(angle_to_circle_target, circle_distance); // work out the radius of the circle around the target
+	circle_move_y = process[circle_target].get_core_y()
+		+ (process[circle_target].get_core_speed_y() * 10)
+		- sin(angle_to_circle_target, circle_distance);
+	auto_move.move_to(circle_move_x, circle_move_y);
+	return; // returns to the statement immediately after the gosub

--- a/bin/proc/cm_tri_base.c
+++ b/bin/proc/cm_tri_base.c
@@ -1,5 +1,3 @@
-
-
 #process "tri_base"
 
 // This process has objects with the following auto classes:
@@ -18,108 +16,101 @@ class auto_att_spike;
 class auto_stability;
 
 core_static_hex_A, 0, 
-  {object_build, 0},
-  {object_downlink, -878, 
-    {component_prong, // component 1
-      {object_pulse:auto_att_fwd, -727},
-      {object_downlink, 913, 
-        {component_fork, // component 2
-          {object_none, 0},
-          {object_pulse:auto_att_right, 0},
-          {object_uplink, 0},
-        }
-      },
-      {object_storage, 0},
-      {object_uplink, 0},
-    }
-  },
-  {object_repair, 0},
-  {object_downlink, -831, 
-    {component_prong, // component 3
-      {object_pulse:auto_att_back, -832},
-      {object_downlink, 781, 
-        {component_fork, // component 4
-          {object_none, 0},
-          {object_pulse:auto_att_back, 0},
-          {object_uplink, 0},
-        }
-      },
-      {object_storage, 0},
-      {object_uplink, 0},
-    }
-  },
-  {object_allocate:auto_allocate, 0},
-  {object_downlink, -865, 
-    {component_prong, // component 5
-      {object_pulse:auto_att_left, -546},
-      {object_downlink, 876, 
-        {component_fork, // component 6
-          {object_none, 0},
-          {object_pulse:auto_att_fwd, 0},
-          {object_uplink, 0},
-        }
-      },
-      {object_harvest:auto_harvest, 0},
-      {object_uplink, 0},
-    }
-  }
+	{object_build, 0},
+	{object_downlink, -878, 
+		{component_prong, // component 1
+			{object_pulse:auto_att_fwd, -727},
+			{object_downlink, 913, 
+				{component_fork, // component 2
+					{object_none, 0},
+					{object_pulse:auto_att_right, 0},
+					{object_uplink, 0},
+				}
+			},
+			{object_storage, 0},
+			{object_uplink, 0},
+		}
+	},
+	{object_repair, 0},
+	{object_downlink, -831, 
+		{component_prong, // component 3
+			{object_pulse:auto_att_back, -832},
+			{object_downlink, 781, 
+				{component_fork, // component 4
+					{object_none, 0},
+					{object_pulse:auto_att_back, 0},
+					{object_uplink, 0},
+				}
+			},
+			{object_storage, 0},
+			{object_uplink, 0},
+		}
+	},
+	{object_allocate:auto_allocate, 0},
+	{object_downlink, -865, 
+		{component_prong, // component 5
+			{object_pulse:auto_att_left, -546},
+			{object_downlink, 876, 
+				{component_fork, // component 6
+					{object_none, 0},
+					{object_pulse:auto_att_fwd, 0},
+					{object_uplink, 0},
+				}
+			},
+			{object_harvest:auto_harvest, 0},
+			{object_uplink, 0},
+		}
+	}
 #code
 
-
-
-
 // Process AI modes (these reflect the capabilities of the process)
-enum
-{
-  MODE_IDLE, // process isn't doing anything ongoing
-  MODES
+enum {
+	MODE_IDLE, // process isn't doing anything ongoing
+	MODES
 };
 
 // Commands that the user may give the process
 // (these are fixed and should not be changed, although not all processes accept all commands)
-enum
-{
-  COM_NONE, // no command
-  COM_LOCATION, // user has right-clicked somewhere on the display or map
-  COM_TARGET, // user has right-clicked on an enemy process
-  COM_FRIEND, // user has right-clicked on a friendly process
-  COM_DATA_WELL // user has right-clicked on a data well
+enum {
+	COM_NONE, // no command
+	COM_LOCATION, // user has right-clicked somewhere on the display or map
+	COM_TARGET, // user has right-clicked on an enemy process
+	COM_FRIEND, // user has right-clicked on a friendly process
+	COM_DATA_WELL // user has right-clicked on a data well
 };
 
 // Targetting information
 // Targetting memory allows processes to track targets (enemy or friend)
 // The following enums are used as indices in the process' targetting memory
-enum
-{
-  TARGET_PARENT, // a newly built process starts with its builder in address 0
-  TARGET_MAIN, // main target
-  TARGET_FRONT, // target of directional forward attack
-  TARGET_LEFT, // target of directional left attack
-  TARGET_RIGHT, // target of directional right attack
-  TARGET_BACK, // target of directional backwards attack
-  TARGET_BUILT, // processes built by this process
-  TARGET_ALLOCATOR, // process that this process will return to when finished harvesting
-  TARGET_SELF_CHECK, // check against self for self-destruct commands
+enum {
+	TARGET_PARENT, // a newly built process starts with its builder in address 0
+	TARGET_MAIN, // main target
+	TARGET_FRONT, // target of directional forward attack
+	TARGET_LEFT, // target of directional left attack
+	TARGET_RIGHT, // target of directional right attack
+	TARGET_BACK, // target of directional backwards attack
+	TARGET_BUILT, // processes built by this process
+	TARGET_ALLOCATOR, // process that this process will return to when finished harvesting
+	TARGET_SELF_CHECK, // check against self for self-destruct commands
 };
 
-
 // Variable declaration and initialisation
-//  (note that declaration and initialisation cannot be combined)
-//  (also, variables retain their values between execution cycles)
+// (note that declaration and initialisation cannot be combined)
+// (also, variables retain their values between execution cycles)
 int core_x, core_y; // location of core
 core_x = get_core_x(); // location is updated each cycle
 core_y = get_core_y();
 int angle; // direction process is pointing
- // angles are in integer degrees from 0 to 8192, with 0 being right,
- // 2048 down, 4096 left and 6144 (or -2048) up.
+// angles are in integer degrees from 0 to 8192, with 0 being right,
+// 2048 down, 4096 left and 6144 (or -2048) up.
 angle = get_core_angle(); // angle is updated each cycle
 
 int mode; // what is the process doing? (should be one of the MODE enums)
 
 int front_attack_primary; // is set to 1 if forward directional attack objects are attacking
- // the primary target (e.g. target selected by command). Set to 0 if the objects are available for autonomous fire.
+// the primary target (e.g. target selected by command). Set to 0 if the objects are available for autonomous fire.
 int target_component; // target component for an attack command (allows user to
- // target specific components)
+// target specific components)
 
 int scan_result; // used to hold the results of a scan of nearby processes
 
@@ -129,103 +120,85 @@ int self_destruct_primed; // counter for confirming self-destruct command (ctrl-
 int build_result; // build result code (returned by build call)
 int initialised; // set to 1 after initialisation code below run the first time
 
-if (!initialised)
-{
-   // initialisation code goes here (not all autocoded processes have initialisation code)
-  initialised = 1;
-  attack_mode(0); // attack objects (if present) will all fire together
+if (!initialised) {
+	// initialisation code goes here (not all autocoded processes have initialisation code)
+	initialised = 1;
+	attack_mode(0); // attack objects (if present) will all fire together
 }
 
 int verbose; // if 1, process will print various things to the console
 
-if (check_selected_single()) // returns 1 if the user has selected this process (and no other processes)
-{
-  if (!verbose) printf("\nProcess selected.");
-  verbose = 1;
-  set_debug_mode(1); // 1 means errors for this process will be printed to the console. Resets to 0 each cycle
+if (check_selected_single()) { // returns 1 if the user has selected this process (and no other processes)
+	if (!verbose)
+		printf("\nProcess selected.");
+	verbose = 1;
+	set_debug_mode(1); // 1 means errors for this process will be printed to the console. Resets to 0 each cycle
+} else {
+	verbose = 0;
 }
-  else
-    verbose = 0;
-
 
 // Accept commands from user
-if (check_new_command() == 1) // returns 1 if a command has been given
-{
-  switch(get_command_type()) // get_command_type() returns the type of command given
-  {
-    case COM_LOCATION:
-    case COM_DATA_WELL: // this process can't harvest, so treat data well commands as location commands
-      if (verbose) printf("\nLocation command will be sent to new processes.");
-      break;
-    
-    case COM_TARGET:
-      if (verbose) printf("\nTarget command will be sent to new processes.");
-      break;
-    
-    case COM_FRIEND:
-      get_command_target(TARGET_SELF_CHECK); // writes the target of the command to address TARGET_SELF_CHECK in targetting memory
-      if (get_command_ctrl() && process[TARGET_SELF_CHECK].get_core_x() == get_core_x() && process[TARGET_SELF_CHECK].get_core_y() == get_core_y())
-      {
-        if (self_destruct_primed > 0)
-        {
-          printf("\nTerminating.");
-          terminate; // this causes the process to self-destruct
-        }
-        printf("\nSelf destruct primed.");
-        printf("\nRepeat command (ctrl-right-click self) to confirm.");
-        self_destruct_primed = 20;
-        break;
-      }
-      if (verbose) printf("\nFriendly target command will be sent to new processes.");
-      break;
-    
-    default:
-      if (verbose) printf("\nUnrecognised command.");
-      break;
-  
-  } // end of command type switch
-} // end of new command code
-
-
-if (self_destruct_primed > 0)
-{
-  self_destruct_primed --;
-  if (self_destruct_primed == 0
-   && verbose)
-    printf("\nSelf destruct cancelled.");
+if (check_new_command() == 1) { // returns 1 if a command has been given
+	switch(get_command_type()) { // get_command_type() returns the type of command given
+	case COM_LOCATION:
+	case COM_DATA_WELL: // this process can't harvest, so treat data well commands as location commands
+		if (verbose)
+			printf("\nLocation command will be sent to new processes.");
+		break;
+	case COM_TARGET:
+		if (verbose)
+			printf("\nTarget command will be sent to new processes.");
+		break;
+	case COM_FRIEND:
+		get_command_target(TARGET_SELF_CHECK); // writes the target of the command to address TARGET_SELF_CHECK in targetting memory
+		if (get_command_ctrl() &&
+			process[TARGET_SELF_CHECK].get_core_x() == get_core_x() &&
+			process[TARGET_SELF_CHECK].get_core_y() == get_core_y()) {
+			if (self_destruct_primed > 0) {
+				printf("\nTerminating.");
+				terminate; // this causes the process to self-destruct
+			}
+			printf("\nSelf destruct primed.");
+			printf("\nRepeat command (ctrl-right-click self) to confirm.");
+			self_destruct_primed = 20;
+			break;
+		}
+		if (verbose)
+			printf("\nFriendly target command will be sent to new processes.");
+		break;
+	default:
+		if (verbose)
+			printf("\nUnrecognised command.");
+		break;
+	}
 }
 
+if (self_destruct_primed > 0) {
+	self_destruct_primed --;
+	if (self_destruct_primed == 0 && verbose)
+		printf("\nSelf destruct cancelled.");
+}
 
 // Now try to build a new process from the build queue.
 // This only does anything if a build command for this process is at the front of the queue.
 // Otherwise, it will just fail.
 if (build_from_queue(TARGET_BUILT) == 1) // returns 1 on success
-  copy_commands(TARGET_BUILT); // copies builder's command queue to newly built process
-
-
-
+	copy_commands(TARGET_BUILT); // copies builder's command queue to newly built process
 
 auto_harvest.gather_data();
 
-
 auto_allocate.allocate_data(4); // actually I think the maximum is 2
-
 
 front_attack_primary = 0; // this will be set to 1 if front attack is attacking the main target
 
-
 // What the process does next depends on its current mode
-switch(mode)
-{
-  
-  case MODE_IDLE:
-    break;
+switch(mode) {
+	case MODE_IDLE:
+		break;
+}
 
-} // end of mode switch
-
-if (front_attack_primary == 0) // is 1 if the forward attack objects are attacking the main target
-{
-  auto_att_fwd.attack_scan(0, 400, TARGET_FRONT);
+if (front_attack_primary == 0) { // is 1 if the forward attack objects are attacking the main target
+	auto_att_fwd.attack_scan(0, 400, TARGET_FRONT);
 }
 
 auto_att_left.attack_scan(-2048, 400, TARGET_LEFT);


### PR DESCRIPTION
Went through all files in `bin/proc` and cleaned up the indentation. The style is following the Linux kernel developments coding style (https://www.kernel.org/doc/html/v4.10/process/coding-style.html). For the most part I left the comments, as I don't want to remove anything that might be useful. The comments do need to be cleaned up though. If the changes to `bin/proc` are acceptable, I will go ahead and fix the entire repositories indentation.